### PR TITLE
v1.14.6: 额度追踪/日历/会话 UI 升级 + GM/刷新修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # 变更日志 / Changelog
 
+## [1.14.6] - 2026-04-01
+
+### ✨ Added / 新增
+
+- **Calendar Monthly Summary Toggle / 日历月度总计切换**: Added segmented toggle buttons (Monthly / All-Time) to the calendar summary section. Users can now instantly see current month's consumption breakdown alongside all-time stats. Default view is monthly. Empty-month states show friendly guidance. Toggle state survives poll refreshes via event delegation.
+  日历汇总区域新增分段切换按钮（月度 / 全部），用户可快速查看本月消耗明细和历史总计。默认显示月度。空月份显示友好提示。通过事件委托机制在自动刷新后保持切换状态。
+
+- **Tab Arrow Navigation / Tab 栏箭头导航**: Added left/right scroll arrow buttons flanking the tab bar. Arrows intelligently show/hide based on overflow state: no overflow = both faded, scrolled to start = left faded, scrolled to end = right faded, middle = both visible. Uses `opacity` + `pointer-events` fade transition (0.25s) instead of `display: none` to **preserve layout space and prevent accidental tab clicks** when an arrow disappears at scroll endpoints. Click scrolls 150px with smooth behavior.
+  Tab 栏两端新增左右箭头滚动按钮，根据溢出状态智能显隐。使用 `opacity` + `pointer-events` 渐隐过渡（0.25s）而非 `display: none`，**保留占位空间防止箭头消失时误触旁边的 Tab**。点击平滑滚动 150px。
+
+- **Quota Tracking Disabled State Feedback / 额度追踪关闭状态反馈**: When quota timeline tracking is disabled in Settings, the Quota Tracking tab now shows a clear "tracking is paused" message with a "Go to Settings" button that navigates directly to the Settings tab, instead of the misleading "No active quota consumption detected" empty state.
+  关闭额度时间线追踪后，额度追踪标签页现在显示明确的「追踪已关闭」提示，并提供「前往设置」按钮一键跳转至设置页，替代此前误导性的「未检测到活跃额度消耗」空状态。
+
+### ✨ Improved / 改进
+
+- **Quota Tracking Toggle Migration / 额度追踪开关迁移**: Moved the quota timeline tracking toggle from the Quota Tracking tab to the Settings tab. Root cause: the polling mechanism (`innerHTML` replacement) destroyed the toggle's event listeners on every refresh cycle. The Settings tab is not subject to incremental DOM updates, ensuring stable state persistence. Default changed to enabled (`true`) since performance overhead is negligible.
+  将额度时间线追踪开关从额度追踪标签页迁移至设置标签页。根因：轮询机制（`innerHTML` 替换）每次刷新都销毁 toggle 的事件监听。设置页不参与增量 DOM 更新，确保状态持久化稳定。默认值改为启用（`true`），性能开销极小。
+
+- **Session Card Visual Overhaul / 会话卡片视觉升级**: Enhanced session history cards with modern aesthetics: `::before` pseudo-element top glow line for depth, 3px green left accent border for current sessions, enhanced multi-layer hover shadows (`4px+12px`), `translateY(-2px)` hover lift, spotlight card hover interactions, upgraded action buttons (`radius-md` + hover float + box-shadow), and comprehensive `body.vscode-light` theme overrides for all card components.
+  会话历史卡片视觉全面升级：顶部柔光线增强层次感、当前会话左侧绿色强调边框、多层 hover 阴影、spotlight 卡片 hover 互动、操作按钮升级圆角 + 微浮效果，以及完整的浅色主题适配。
+
+### 🐛 Fixed / 修复
+
+- **Session Card Animation Re-Triggering / 会话卡片动画反复触发**: Removed the `historyRowSlideIn` staggered entry animation that re-triggered on every poll refresh. Root cause: CSS animations always fire on newly-inserted DOM elements, and the polling architecture replaces `innerHTML` entirely — creating new elements each cycle. This is architecturally incompatible with CSS `@keyframes` animations.
+  移除了每次轮询刷新时反复触发的 `historyRowSlideIn` 交错入场动画。根因：CSS 动画在新插入的 DOM 元素上必然重新触发，而轮询架构每个周期都通过 `innerHTML` 替换创建全新元素，与 CSS `@keyframes` 动画在架构上不兼容。
+
+### 📊 Stats / 统计
+
+- **Files changed**: 6 (webview-history-tab.ts, webview-settings-tab.ts, webview-script.ts, webview-styles.ts, webview-panel.ts, quota-tracker.ts)
+- **TypeScript compile**: Zero errors
+
+---
+
 ## [1.14.5] - 2026-04-01
+
 
 ### 🐛 Fixed / 修复
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
 - **Session Card Animation Re-Triggering / 会话卡片动画反复触发**: Removed the `historyRowSlideIn` staggered entry animation that re-triggered on every poll refresh. Root cause: CSS animations always fire on newly-inserted DOM elements, and the polling architecture replaces `innerHTML` entirely — creating new elements each cycle. This is architecturally incompatible with CSS `@keyframes` animations.
   移除了每次轮询刷新时反复触发的 `historyRowSlideIn` 交错入场动画。根因：CSS 动画在新插入的 DOM 元素上必然重新触发，而轮询架构每个周期都通过 `innerHTML` 替换创建全新元素，与 CSS `@keyframes` 动画在架构上不兼容。
 
+- **GM Prompt Snippet Falling Back to Internal IDs / GM 提示摘要误回退到内部 ID**: Fixed cases where GM prompt extraction preferred opaque internal identifiers such as `bot-*`, `toolu_*`, `req_vrtx_*`, or `session-*` over actual prompt text, which could make Activity rows display unreadable IDs or backfill planner / GM virtual rows with misleading pseudo-responses. The extractor now filters internal identifier fields, requires prompt-like paths, and keeps structural timeline rows focused on tool and step metadata instead of synthetic AI text.
+  修复 GM prompt 摘要提取误把 `bot-*`、`toolu_*`、`req_vrtx_*`、`session-*` 这类内部标识当成真实提示文本的问题，避免 Activity 时间线出现不可读的内部 ID，或把 planner / GM virtual 结构化行错误回填成伪造的 AI 回复。现在提取器会过滤内部标识字段、要求更像 prompt 的路径命名，并让结构化时间线行继续只展示工具与步序元数据。
+
+- **Quota History Clear Button / 已完成会话清理按钮**: Added a dedicated Clear button next to “Completed Sessions” in the Quota Tracking tab. The action is intentionally scoped to archived history only, while the existing “Active Tracking” clear button still clears runtime tracking state. This keeps the two buttons visually consistent without mixing their responsibilities. Also tuned the header row spacing so the new action button keeps comfortable breathing room from the summary content below.
+  在额度追踪标签页的「已完成会话」标题旁新增独立的清理按钮。该按钮只清除归档历史，不影响当前活跃追踪；原有「活跃追踪」清理按钮仍只负责清空运行中的 tracking state。这样既保持交互外观一致，也避免两种清理语义互相误伤。同时补了标题行与下方汇总区域之间的留白，让新增按钮不会和下方内容贴得过紧。
+
+- **End-of-Content Fade-In Repeating on Poll Refresh / 「已到底」提示在轮询刷新时反复淡入**: Fixed the repeated fade-in of the end-of-content sentinel across Monitor, GM Data, Sessions, Cost, Models, and Quota Tracking during incremental panel updates. Root cause: unchanged tabs were still having their `innerHTML` replaced, causing the sentinel to be recreated and re-observed as a brand-new node on every poll. Fix: cache per-tab HTML, skip unchanged pane swaps, preserve visible sentinel state across refreshes, and restore it with a no-transition path when needed. Also added idempotent listener guards for refreshed `<details>` blocks and session catalog filters to prevent duplicate bindings.
+  修复监控、GM 数据、会话、成本、模型、额度追踪等标签页中「已到底」提示在增量轮询刷新时反复触发淡入的问题。根因：即使内容未变化，标签页仍会执行 `innerHTML` 替换，导致 sentinel 节点每次都被重建并重新交给观察器，浏览器把它当成全新元素再次播放淡入。修复方式：缓存各标签页 HTML、跳过未变化 pane 的 DOM 替换、在刷新后保留已可见 sentinel 的状态，并在需要时用无过渡方式恢复。同时为刷新后重新出现的 `<details>` 和会话目录筛选控件增加幂等监听保护，避免重复绑定事件。
+
 ### 📊 Stats / 统计
 
 - **Files changed**: 6 (webview-history-tab.ts, webview-settings-tab.ts, webview-script.ts, webview-styles.ts, webview-panel.ts, quota-tracker.ts)

--- a/src/activity-tracker.ts
+++ b/src/activity-tracker.ts
@@ -353,6 +353,9 @@ function isLowSignalPromptSnippet(snippet: string): boolean {
     const clean = snippet.replace(/\s+/g, ' ').trim();
     if (!clean) { return true; }
     if (clean.length < 12) { return true; }
+    if (/^bot-[0-9a-f-]{8,}$/i.test(clean)) { return true; }
+    if (/^toolu_[a-z0-9_-]{8,}$/i.test(clean)) { return true; }
+    if (/^req_vrtx_[a-z0-9_-]{8,}$/i.test(clean)) { return true; }
     if (/^Step Id:\s*\d+\s+\{\{\s*CHECKPOINT/i.test(clean)) { return true; }
     if (/earlier parts of this conversation/i.test(clean)) { return true; }
     if (/conversation have been compressed/i.test(clean)) { return true; }
@@ -380,28 +383,19 @@ function extractNotifyMessage(toolCalls: unknown[] | undefined): string {
 }
 
 function buildGMVirtualPreview(call: GMCallEntry): { detail: string; aiResponse?: string; fullAiResponse?: string } {
-    const firstIdx = call.stepIndices.length > 0 ? Math.min(...call.stepIndices) : -1;
-    const stepSpan = call.stepIndices.length > 1
-        ? ` +${call.stepIndices.length - 1}`
-        : '';
-
-    if (call.promptSnippet && !isLowSignalPromptSnippet(call.promptSnippet)) {
-        return {
-            detail: call.promptSource === 'messageMetadata' ? 'GM meta' : 'GM prompt',
-            aiResponse: truncate(call.promptSnippet, 96),
-            fullAiResponse: call.promptSnippet.length > 96 ? truncate(call.promptSnippet, 2000) : undefined,
-        };
-    }
-
+    const structuredBits: string[] = [];
     if (call.toolNames.length > 0) {
-        return {
-            detail: `tools: ${call.toolNames.slice(0, 3).join(', ')}`,
-        };
+        structuredBits.push(`${tBi('tools', '工具')}: ${call.toolNames.slice(0, 3).join(', ')}`);
+    }
+    if (call.latestStableMessageIndex > 0) {
+        structuredBits.push(`stable#${call.latestStableMessageIndex}`);
+    } else if (call.startStepIndex > 0) {
+        structuredBits.push(`start#${call.startStepIndex}`);
+    } else if (call.executionId) {
+        structuredBits.push(`exec ${call.executionId.substring(0, 8)}`);
     }
 
-    // Fallback: no useful detail to show (stepIndex is already displayed via #xxx,
-    // and GM token data is shown via right-side tags)
-    return { detail: '' };
+    return { detail: structuredBits.join(' · ') || tBi('GM call', 'GM 调用') };
 }
 
 function sameStepDistribution(a: Record<string, number>, b: Record<string, number>): boolean {
@@ -1766,10 +1760,6 @@ export class ActivityTracker {
                 ev.modelBasis = 'gm_exact';
             } else if (ev.source !== 'estimated') {
                 ev.modelBasis = 'gm_placeholder';
-            }
-            if (!ev.aiResponse && gm.promptSnippet && !isLowSignalPromptSnippet(gm.promptSnippet)) {
-                ev.aiResponse = truncate(gm.promptSnippet, 96);
-                if (gm.promptSnippet.length > 96) { ev.fullAiResponse = truncate(gm.promptSnippet, 2000); }
             }
             if (ev.source === 'estimated' && gm.modelDisplay) {
                 ev.model = normalizeModelDisplayName(gm.modelDisplay || gm.model) || gm.modelDisplay || gm.model;

--- a/src/gm-tracker.ts
+++ b/src/gm-tracker.ts
@@ -691,7 +691,23 @@ function collectStringLeaves(
     }
 }
 
-function pickPromptSnippet(value: unknown): string {
+function tokenizePromptPath(path: string): string[] {
+    return path
+        .toLowerCase()
+        .replace(/\[\d+\]/g, '.')
+        .split('.')
+        .filter(Boolean);
+}
+
+function isInternalPromptValue(value: string): boolean {
+    const clean = value.trim();
+    return /^bot-[0-9a-f-]{8,}$/i.test(clean)
+        || /^toolu_[a-z0-9_-]{8,}$/i.test(clean)
+        || /^req_vrtx_[a-z0-9_-]{8,}$/i.test(clean)
+        || /^session-[0-9a-f-]{8,}$/i.test(clean);
+}
+
+export function pickPromptSnippet(value: unknown): string {
     const strings: Array<{ path: string; value: string }> = [];
     collectStringLeaves(value, '', strings);
     if (strings.length === 0) { return ''; }
@@ -699,24 +715,30 @@ function pickPromptSnippet(value: unknown): string {
     const preferred = [
         'text',
         'content',
-        'message',
         'prompt',
         'summary',
         'query',
         'command',
         'task',
         'title',
-        'name',
-        'path',
+        'message',
+        'description',
     ];
 
     const filtered = strings
         .filter(entry => {
             const lowerPath = entry.path.toLowerCase();
             const lowerValue = entry.value.toLowerCase();
+            const pathTokens = tokenizePromptPath(lowerPath);
+            const hasPreferredPath = preferred.some(token => pathTokens.some(part => part.includes(token)));
             if (lowerPath.includes('systemprompt')) { return false; }
             if (lowerPath.includes('checksum')) { return false; }
+            if (pathTokens.some(part => part === 'messageid' || part === 'responseid' || part === 'sessionid' || part === 'executionid')) {
+                return false;
+            }
             if (lowerValue.startsWith('http://') || lowerValue.startsWith('https://')) { return false; }
+            if (isInternalPromptValue(entry.value)) { return false; }
+            if (!hasPreferredPath) { return false; }
             return entry.value.length >= 8;
         })
         .sort((a, b) => {

--- a/src/quota-tracker.ts
+++ b/src/quota-tracker.ts
@@ -101,7 +101,7 @@ export class QuotaTracker {
     private modelStates = new Map<string, ModelState>();
     private history: QuotaSession[] = [];
     private maxHistory: number = DEFAULT_MAX_HISTORY;
-    private enabled: boolean = false;
+    private enabled: boolean = true;
     private context: vscode.ExtensionContext;
     private state: StateBucket;
     private _onQuotaReset?: (modelIds: string[]) => void;
@@ -615,7 +615,7 @@ export class QuotaTracker {
     private restore(): void {
         this.history = this.state.get<QuotaSession[]>(STORAGE_KEY, []);
         this.maxHistory = this.state.get<number>(MAX_HISTORY_KEY, DEFAULT_MAX_HISTORY);
-        this.enabled = this.state.get<boolean>(ENABLED_KEY, false);
+        this.enabled = this.state.get<boolean>(ENABLED_KEY, true);
 
         const activeState = this.state.get<Record<string, ModelState> | undefined>(ACTIVE_KEY, undefined);
         if (activeState) {

--- a/src/webview-calendar-tab.ts
+++ b/src/webview-calendar-tab.ts
@@ -88,7 +88,24 @@ export function buildCalendarTabContent(store?: DailyStore, year?: number, month
 
     // ── Stats Summary (top position for quick overview) ──
     if (store.totalDays > 0) {
-        parts.push(buildOverallSummary(store));
+        const allTimeSummary = buildOverallSummaryGrid(store);
+        const monthlySummary = buildMonthlySummaryGrid(store, currentYear, currentMonth);
+        parts.push(`
+            <section class="card">
+                <div class="cal-summary-header">
+                    <h2>${ICON.chart} ${tBi('Usage Summary', '用量汇总')}</h2>
+                    <div class="cal-summary-toggle" id="calSummaryToggle">
+                        <button class="cal-summary-btn active" data-summary-mode="monthly">${tBi('Monthly', '月度')}</button>
+                        <button class="cal-summary-btn" data-summary-mode="alltime">${tBi('All-Time', '全部')}</button>
+                    </div>
+                </div>
+                <div class="cal-summary-pane" id="calSummaryMonthly" style="display:block">
+                    ${monthlySummary}
+                </div>
+                <div class="cal-summary-pane" id="calSummaryAllTime" style="display:none">
+                    ${allTimeSummary}
+                </div>
+            </section>`);
     }
 
     // ── Month Navigation + Grid ──
@@ -618,6 +635,72 @@ export function getCalendarTabStyles(): string {
         body.vscode-light .cal-cell.has-data { background: rgba(0,0,0,0.03); }
         body.vscode-light .cal-cycle { background: rgba(0,0,0,0.015); }
         body.vscode-light .cal-detail { background: rgba(37,99,235,0.03); border-color: rgba(37,99,235,0.15); }
+
+        /* ─── Calendar Summary Toggle ──── */
+        .cal-summary-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--space-2);
+            margin-bottom: var(--space-3);
+        }
+        .cal-summary-header h2 {
+            margin-bottom: 0;
+        }
+        .cal-summary-toggle {
+            display: flex;
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-md);
+            overflow: hidden;
+            flex-shrink: 0;
+        }
+        .cal-summary-btn {
+            appearance: none;
+            background: transparent;
+            color: var(--color-text-dim);
+            border: none;
+            padding: var(--space-1) var(--space-3);
+            font: inherit;
+            font-size: 0.76em;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s cubic-bezier(.4,0,.2,1), color 0.2s cubic-bezier(.4,0,.2,1);
+            border-right: 1px solid var(--color-border);
+        }
+        .cal-summary-btn:last-child { border-right: none; }
+        .cal-summary-btn.active {
+            background: var(--color-info);
+            color: #fff;
+        }
+        .cal-summary-btn:focus-visible {
+            box-shadow: 0 0 0 2px var(--color-info);
+            outline: none;
+        }
+        .cal-summary-btn:active { transform: scale(0.97); }
+        @media (hover: hover) {
+            .cal-summary-btn:not(.active):hover {
+                background: rgba(255,255,255,0.08);
+                color: var(--color-text);
+            }
+        }
+        .cal-summary-pane {
+            animation: calSummaryFadeIn 0.25s ease-out;
+        }
+        @keyframes calSummaryFadeIn {
+            from { opacity: 0; transform: translateY(-4px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .cal-summary-empty {
+            color: var(--color-text-dim);
+            font-size: 0.85em;
+            text-align: center;
+            padding: var(--space-3) 0;
+            opacity: 0.7;
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .cal-summary-pane { animation: none; }
+            .cal-summary-btn { transition: none; }
+        }
     `;
 }
 
@@ -996,7 +1079,7 @@ function buildGMModelRows(gmModelStats?: Record<string, GMModelCycleStats>): str
     return html;
 }
 
-function buildOverallSummary(store: DailyStore): string {
+function buildOverallSummaryGrid(store: DailyStore): string {
     const dates = store.getDatesWithData();
     let totalReasoning = 0, totalToolCalls = 0, totalCost = 0, totalCycles = 0;
     let totalErrors = 0, totalGMCalls = 0, totalGMCredits = 0, totalGMTokens = 0;
@@ -1020,51 +1103,99 @@ function buildOverallSummary(store: DailyStore): string {
         }
     }
 
+    return buildSummaryOverviewGrid(dates.length, totalCycles, totalReasoning, totalToolCalls, totalGMTokens, totalCost, totalGMCredits, totalGMCalls, totalErrors);
+}
+
+function buildMonthlySummaryGrid(store: DailyStore, year: number, month: number): string {
+    const prefix = `${year}-${String(month).padStart(2, '0')}`;
+    const dates = store.getDatesWithData().filter(d => d.startsWith(prefix));
+
+    if (dates.length === 0) {
+        const lang = getLanguage();
+        const monthLabel = lang === 'en'
+            ? `${MONTH_NAMES_EN[month - 1]} ${year}`
+            : `${year}年${MONTH_NAMES_ZH[month - 1]}`;
+        return `<p class="cal-summary-empty">${tBi(
+            `No data for ${monthLabel} yet.`,
+            `${monthLabel}暂无数据。`,
+        )}</p>`;
+    }
+
+    let totalReasoning = 0, totalToolCalls = 0, totalCost = 0, totalCycles = 0;
+    let totalErrors = 0, totalGMCalls = 0, totalGMCredits = 0, totalGMTokens = 0;
+
+    for (const date of dates) {
+        const record = store.getRecord(date);
+        if (!record) { continue; }
+        for (const c of record.cycles) {
+            totalCycles++;
+            totalReasoning += c.totalReasoning;
+            totalToolCalls += c.totalToolCalls;
+            totalCost += c.estimatedCost || 0;
+            totalErrors += c.totalErrors;
+            totalGMCalls += c.gmTotalCalls || 0;
+            totalGMCredits += c.gmTotalCredits || 0;
+            if (c.gmModelStats) {
+                for (const gm of Object.values(c.gmModelStats)) {
+                    totalGMTokens += gm.inputTokens + gm.outputTokens;
+                }
+            }
+        }
+    }
+
+    return buildSummaryOverviewGrid(dates.length, totalCycles, totalReasoning, totalToolCalls, totalGMTokens, totalCost, totalGMCredits, totalGMCalls, totalErrors);
+}
+
+/** Shared grid builder for all-time and monthly summaries */
+function buildSummaryOverviewGrid(
+    dayCount: number, cycleCount: number,
+    reasoning: number, toolCalls: number,
+    gmTokens: number, cost: number,
+    gmCredits: number, gmCalls: number,
+    errors: number,
+): string {
     return `
-        <section class="card">
-            <h2>${ICON.chart} ${tBi('All-Time Summary', '历史汇总')}</h2>
             <div class="cal-overview-grid">
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${dates.length}</div>
+                    <div class="cal-overview-val">${dayCount}</div>
                     <div class="cal-overview-label">${tBi('Days', '天数')}</div>
                 </div>
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${totalCycles}</div>
+                    <div class="cal-overview-val">${cycleCount}</div>
                     <div class="cal-overview-label">${tBi('Cycles', '周期')}</div>
                 </div>
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${totalReasoning}</div>
+                    <div class="cal-overview-val">${reasoning}</div>
                     <div class="cal-overview-label">${tBi('Reasoning', '推理')}</div>
                 </div>
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${totalToolCalls}</div>
+                    <div class="cal-overview-val">${toolCalls}</div>
                     <div class="cal-overview-label">${tBi('Tools', '工具')}</div>
                 </div>
-                ${totalGMTokens > 0 ? `
+                ${gmTokens > 0 ? `
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${formatTokensK(totalGMTokens)}</div>
+                    <div class="cal-overview-val">${formatTokensK(gmTokens)}</div>
                     <div class="cal-overview-label">${tBi('Tokens', '令牌')}</div>
                 </div>` : ''}
-                ${totalCost > 0 ? `
+                ${cost > 0 ? `
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${formatCost(totalCost)}</div>
-                    <div class="cal-overview-label">${tBi('Total Cost', '总费用')}</div>
+                    <div class="cal-overview-val">${formatCost(cost)}</div>
+                    <div class="cal-overview-label">${tBi('Cost', '费用')}</div>
                 </div>` : ''}
-                ${totalGMCredits > 0 ? `
+                ${gmCredits > 0 ? `
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${totalGMCredits}</div>
+                    <div class="cal-overview-val">${gmCredits}</div>
                     <div class="cal-overview-label">${tBi('Credits', '积分')}</div>
                 </div>` : ''}
-                ${totalGMCalls > 0 ? `
+                ${gmCalls > 0 ? `
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val">${totalGMCalls}</div>
+                    <div class="cal-overview-val">${gmCalls}</div>
                     <div class="cal-overview-label">${tBi('GM Calls', 'GM 调用')}</div>
                 </div>` : ''}
-                ${totalErrors > 0 ? `
+                ${errors > 0 ? `
                 <div class="cal-overview-item">
-                    <div class="cal-overview-val cal-day-total-danger">${totalErrors}</div>
+                    <div class="cal-overview-val cal-day-total-danger">${errors}</div>
                     <div class="cal-overview-label">${tBi('Errors', '错误')}</div>
                 </div>` : ''}
-            </div>
-        </section>`;
+            </div>`;
 }

--- a/src/webview-history-tab.ts
+++ b/src/webview-history-tab.ts
@@ -1,6 +1,6 @@
 // ─── Quota Tracking Tab Content Builder ──────────────────────────────────────
-// Builds HTML for the "Quota Tracking" tab: quota tracking toggle, active
-// sessions with progress bars, and completed session history with summary stats.
+// Builds HTML for the "Quota Tracking" tab: active sessions with progress bars,
+// and completed session history with summary stats.
 // Archived history and usage history have been migrated to Calendar.
 
 import { tBi } from './i18n';
@@ -24,33 +24,28 @@ export function buildHistoryHtml(tracker?: QuotaTracker): string {
             </section>`;
     }
 
-    const isEnabled = tracker.isEnabled();
     const parts: string[] = [];
 
-    // ── Enable/Disable Toggle ──
-    parts.push(`
-        <section class="card">
-            <h2>${ICON.timeline} ${tBi('Quota Timeline', '额度时间线')}</h2>
-            <div class="toggle-group">
-                <label class="toggle-row" id="quotaTrackingToggle">
-                    <input type="checkbox" class="toggle-cb" ${isEnabled ? 'checked' : ''} />
-                    <span class="toggle-track"><span class="toggle-thumb"></span></span>
-                    <span>${tBi('Enable quota consumption tracking', '启用额度消耗追踪')}</span>
-                </label>
-            </div>
-            <p class="raw-desc">${tBi(
-                'Tracks quota usage against the official resetTime. No fixed 5-hour assumption. Default off.',
-                '基于官方 resetTime 追踪额度使用，不再假设固定 5 小时周期。默认关闭。',
-            )}</p>
-        </section>`);
-
-    if (!isEnabled) {
+    // ── Disabled State ──
+    if (!tracker.isEnabled()) {
+        parts.push(`
+            <section class="card empty">
+                <h2>${ICON.timeline} ${tBi('Quota Timeline', '额度时间线')}</h2>
+                <p class="empty-desc">${tBi(
+                    'Quota timeline tracking is currently disabled. Enable it in the Settings tab to start monitoring quota consumption.',
+                    '额度时间线追踪已关闭。请在「设置」标签页中启用以开始监控额度消耗。',
+                )}</p>
+                <button class="action-btn" id="goToSettingsFromQuota" style="margin-top:var(--space-2)">
+                    ${ICON.shield} ${tBi('Go to Settings', '前往设置')}
+                </button>
+            </section>`);
         return parts.join('');
     }
 
     const activeSessions = tracker.getActiveSessions();
     const history = tracker.getHistory();
     const maxHistory = tracker.getMaxHistory();
+
 
     // ── Active Tracking ──
     if (activeSessions.length > 0) {
@@ -209,7 +204,7 @@ function buildSessionCard(session: QuotaSession, isActive: boolean): string {
                 </div>
             </div>` : '';
 
-        const isFirst = shouldCollapse ? idx === 0 : idx === 0;
+        const isFirst = idx === 0;
         const isLast = (shouldCollapse ? idx === visibleSnapshots.length - 1 : idx === session.snapshots.length - 1) && session.completed;
 
         return `${hiddenMarkerHtml}

--- a/src/webview-history-tab.ts
+++ b/src/webview-history-tab.ts
@@ -81,7 +81,12 @@ export function buildHistoryHtml(tracker?: QuotaTracker): string {
         const historyCards = history.map(s => buildSessionCard(s, false)).join('');
         parts.push(`
             <section class="card">
-                <h2>${ICON.clock} ${tBi('Completed Sessions', '已完成会话')} (${history.length}/${maxHistory})</h2>
+                <div class="card-header-row">
+                    <h2>${ICON.clock} ${tBi('Completed Sessions', '已完成会话')} (${history.length}/${maxHistory})</h2>
+                    <button class="action-btn danger-action qt-clear-history" id="clearQuotaHistory">
+                        ${ICON.trash} ${tBi('Clear', '清理')}
+                    </button>
+                </div>
                 ${summaryBar}
                 ${historyCards}
             </section>`);

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -448,7 +448,6 @@ export function showMonitorPanel(p: PanelPayload): void {
             }
         } else if (msg.command === 'clearQuotaHistory') {
             if (lastQuotaTracker) {
-                lastQuotaTracker.resetTrackingStates();
                 lastQuotaTracker.clearHistory();
                 refreshLocalStorageDiagnostics();
                 if (panel) {

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -724,7 +724,11 @@ ${getCalendarTabStyles()}
                 )}
             </div>
         </div>
-        <nav class="tab-bar">
+        <div class="tab-bar-wrapper">
+        <button class="tab-arrow tab-arrow-left is-faded" id="tabArrowLeft" aria-label="${tBi('Scroll tabs left', '向左滚动标签')}">
+            <svg viewBox="0 0 16 16" width="14" height="14"><path fill="currentColor" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/></svg>
+        </button>
+        <nav class="tab-bar" id="tabBar">
         <div class="tab-slider"></div>
         <button class="tab-btn active" data-tab="monitor" data-color="blue">${ICON.chart} ${tBi('Monitor', '监控')}</button>
         <button class="tab-btn" data-tab="gmdata" data-color="orange">${ICON.bolt} ${tBi('GM Data', 'GM 数据')}</button>
@@ -736,6 +740,11 @@ ${getCalendarTabStyles()}
         <button class="tab-btn" data-tab="profile" data-color="gray">${ICON.user} ${tBi('Profile', '个人')}</button>
         <button class="tab-btn" data-tab="settings" data-color="gray">${ICON.shield} ${tBi('Settings', '设置')}</button>
     </nav>
+        <button class="tab-arrow tab-arrow-right is-faded" id="tabArrowRight" aria-label="${tBi('Scroll tabs right', '向右滚动标签')}">
+            <svg viewBox="0 0 16 16" width="14" height="14"><path fill="currentColor" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/></svg>
+        </button>
+    </div>
+
     <div class="tab-scroll-hint" id="tabScrollHint" hidden>
         <span class="tab-scroll-hint-text">${ICON.timeline} <span>${tBi('Too many tabs? Hold Shift and use the mouse wheel to scroll horizontally.', '标签过多时，可按住 Shift 再滚动鼠标滚轮进行横向滚动。')}</span></span>
         <button class="tab-scroll-hint-close" id="dismissTabScrollHint" aria-label="${tBi('Dismiss tab scroll hint', '关闭标签滚动提示')}">

--- a/src/webview-script.ts
+++ b/src/webview-script.ts
@@ -106,6 +106,8 @@ export function getScript(): string {
 
                 updateTabSlider();
                 updateTabOverflowHint();
+                updateTabArrows();
+
 
                 // Restore incoming tab scroll position
                 tabScrolls = ts; // Update local ref
@@ -120,11 +122,13 @@ export function getScript(): string {
             if (tabBarEl) {
                 tabBarEl.addEventListener('scroll', function() {
                     updateTabOverflowHint();
+                    updateTabArrows();
                 }, { passive: true });
             }
             window.addEventListener('resize', function() {
                 updateTabSlider();
                 updateTabOverflowHint();
+                updateTabArrows();
             });
             var dismissTabHintBtn = document.getElementById('dismissTabScrollHint');
             if (dismissTabHintBtn) {
@@ -136,6 +140,42 @@ export function getScript(): string {
                     vscode.postMessage({ command: 'setPanelPref', key: 'panelShowTabScrollHint', value: false });
                 });
             }
+
+            // ─── Tab Arrow Navigation ───
+            function updateTabArrows() {
+                var bar = document.querySelector('.tab-bar');
+                var arrowL = document.getElementById('tabArrowLeft');
+                var arrowR = document.getElementById('tabArrowRight');
+                if (!bar || !arrowL || !arrowR) return;
+                var overflowX = Math.ceil(bar.scrollWidth - bar.clientWidth);
+                if (overflowX <= 4) {
+                    // No overflow — fade both arrows out (keep layout space)
+                    arrowL.classList.add('is-faded');
+                    arrowR.classList.add('is-faded');
+                    return;
+                }
+                // Fade based on scroll position
+                arrowL.classList.toggle('is-faded', bar.scrollLeft <= 4);
+                arrowR.classList.toggle('is-faded', bar.scrollLeft >= overflowX - 4);
+            }
+
+            requestAnimationFrame(function() { updateTabArrows(); });
+
+            var tabArrowL = document.getElementById('tabArrowLeft');
+            var tabArrowR = document.getElementById('tabArrowRight');
+            if (tabArrowL) {
+                tabArrowL.addEventListener('click', function() {
+                    var bar = document.querySelector('.tab-bar');
+                    if (bar) { bar.scrollBy({ left: -150, behavior: 'smooth' }); }
+                });
+            }
+            if (tabArrowR) {
+                tabArrowR.addEventListener('click', function() {
+                    var bar = document.querySelector('.tab-bar');
+                    if (bar) { bar.scrollBy({ left: 150, behavior: 'smooth' }); }
+                });
+            }
+
 
             // ─── Calendar: Restore expanded date after refresh ───
             var calSelectedDate = savedState.calendarSelectedDate || '';
@@ -561,16 +601,14 @@ export function getScript(): string {
                 });
             }
 
-            // ─── Quota Tracking Toggle ───
-            var trackingToggle = document.getElementById('quotaTrackingToggle');
-            if (trackingToggle) {
-                var cb = trackingToggle.querySelector('input[type="checkbox"]');
-                if (cb) {
-                    cb.addEventListener('change', function() {
-                        vscode.postMessage({ command: 'toggleQuotaTracking' });
-                    });
-                }
+            // ─── Quota Timeline Tracking Toggle (Settings tab) ───
+            var quotaTrackingCb = document.getElementById('toggleQuotaTracking');
+            if (quotaTrackingCb) {
+                quotaTrackingCb.addEventListener('change', function() {
+                    vscode.postMessage({ command: 'toggleQuotaTracking' });
+                });
             }
+
 
             // clearActiveTracking: handled by body delegation below
 
@@ -807,6 +845,13 @@ export function getScript(): string {
                     return;
                 }
 
+                // ── Go to Settings from Quota Tracking disabled state ──
+                if (target.closest('#goToSettingsFromQuota')) {
+                    switchTab('settings');
+                    return;
+                }
+
+
                 // ── Chat History actions ──
                 var historyBtn = target.closest('[data-history-action]');
                 if (historyBtn) {
@@ -817,6 +862,30 @@ export function getScript(): string {
                         cascadeId: historyBtn.getAttribute('data-cascade-id') || '',
                         uri: historyBtn.getAttribute('data-history-uri') || ''
                     });
+                    return;
+                }
+
+                // ── Calendar Summary Toggle (Monthly / All-Time) ──
+                var summaryBtn = target.closest('.cal-summary-btn');
+                if (summaryBtn) {
+                    var mode = summaryBtn.getAttribute('data-summary-mode');
+                    var monthlyPane = document.getElementById('calSummaryMonthly');
+                    var alltimePane = document.getElementById('calSummaryAllTime');
+                    var toggleWrap = summaryBtn.closest('.cal-summary-toggle');
+                    if (toggleWrap) {
+                        var btns = toggleWrap.querySelectorAll('.cal-summary-btn');
+                        for (var sb = 0; sb < btns.length; sb++) { btns[sb].classList.remove('active'); }
+                        summaryBtn.classList.add('active');
+                    }
+                    if (monthlyPane && alltimePane) {
+                        if (mode === 'alltime') {
+                            monthlyPane.style.display = 'none';
+                            alltimePane.style.display = 'block';
+                        } else {
+                            monthlyPane.style.display = 'block';
+                            alltimePane.style.display = 'none';
+                        }
+                    }
                     return;
                 }
 

--- a/src/webview-script.ts
+++ b/src/webview-script.ts
@@ -39,6 +39,48 @@ export function getScript(): string {
             var activeTab = savedState.activeTab || 'monitor';
             var tabBtns = document.querySelectorAll('.tab-btn');
             var tabPanes = document.querySelectorAll('.tab-pane');
+            var lastTabHtmls = {};
+            var eocVisibleTabs = {};
+
+            function getTabNameFromPaneId(paneId) {
+                return paneId && paneId.indexOf('tab-') === 0 ? paneId.substring(4) : '';
+            }
+            function getTabNameFromNode(node) {
+                var pane = node && node.closest ? node.closest('.tab-pane') : null;
+                return pane ? getTabNameFromPaneId(pane.id || '') : '';
+            }
+            function captureVisibleEocTabs() {
+                var visibleTabs = {};
+                for (var pi = 0; pi < tabPanes.length; pi++) {
+                    var paneName = getTabNameFromPaneId(tabPanes[pi].id || '');
+                    if (!paneName) { continue; }
+                    var sentinel = tabPanes[pi].querySelector('.eoc-sentinel');
+                    if (sentinel && sentinel.classList.contains('eoc-visible')) {
+                        visibleTabs[paneName] = true;
+                        eocVisibleTabs[paneName] = true;
+                    }
+                }
+                return visibleTabs;
+            }
+            function restoreVisibleEoc(tabName) {
+                var pane = document.getElementById('tab-' + tabName);
+                if (!pane) { return; }
+                var sentinel = pane.querySelector('.eoc-sentinel');
+                if (!sentinel) { return; }
+                sentinel.classList.add('eoc-no-transition');
+                sentinel.classList.add('eoc-visible');
+                requestAnimationFrame(function() {
+                    requestAnimationFrame(function() {
+                        sentinel.classList.remove('eoc-no-transition');
+                    });
+                });
+            }
+            for (var tp = 0; tp < tabPanes.length; tp++) {
+                var initialTabName = getTabNameFromPaneId(tabPanes[tp].id || '');
+                if (initialTabName) {
+                    lastTabHtmls[initialTabName] = tabPanes[tp].innerHTML;
+                }
+            }
 
             // ─── Tab Slider: position & color ───
             var colorMap = {
@@ -237,13 +279,16 @@ export function getScript(): string {
                     if (Object.prototype.hasOwnProperty.call(ds, det.id)) {
                         det.open = !!ds[det.id];
                     }
-                    det.addEventListener('toggle', function() {
-                        var s = vscode.getState() || {};
-                        var dso = s.detailsOpen || {};
-                        dso[this.id] = this.open;
-                        s.detailsOpen = dso;
-                        vscode.setState(s);
-                    });
+                    if (det.getAttribute('data-details-bound') !== 'true') {
+                        det.addEventListener('toggle', function() {
+                            var s = vscode.getState() || {};
+                            var dso = s.detailsOpen || {};
+                            dso[this.id] = this.open;
+                            s.detailsOpen = dso;
+                            vscode.setState(s);
+                        });
+                        det.setAttribute('data-details-bound', 'true');
+                    }
                 }
             }
 
@@ -285,41 +330,48 @@ export function getScript(): string {
                     }
                 }
 
-                if (searchInput) {
+                if (searchInput && searchInput.getAttribute('data-history-bound') !== 'true') {
                     searchInput.addEventListener('input', function() {
                         var s = vscode.getState() || {};
                         s.historySearch = this.value || '';
                         vscode.setState(s);
                         applyHistoryFilters();
                     });
+                    searchInput.setAttribute('data-history-bound', 'true');
                 }
 
                 for (var fi = 0; fi < filterBtns.length; fi++) {
-                    filterBtns[fi].addEventListener('click', function() {
-                        activeFilter = this.dataset.historyFilter || 'all';
-                        var s = vscode.getState() || {};
-                        s.historyFilter = activeFilter;
-                        vscode.setState(s);
-                        for (var bi = 0; bi < filterBtns.length; bi++) {
-                            filterBtns[bi].classList.toggle('is-active', filterBtns[bi] === this);
-                        }
-                        applyHistoryFilters();
-                    });
+                    if (filterBtns[fi].getAttribute('data-history-bound') !== 'true') {
+                        filterBtns[fi].addEventListener('click', function() {
+                            activeFilter = this.dataset.historyFilter || 'all';
+                            var s = vscode.getState() || {};
+                            s.historyFilter = activeFilter;
+                            vscode.setState(s);
+                            for (var bi = 0; bi < filterBtns.length; bi++) {
+                                filterBtns[bi].classList.toggle('is-active', filterBtns[bi] === this);
+                            }
+                            applyHistoryFilters();
+                        });
+                        filterBtns[fi].setAttribute('data-history-bound', 'true');
+                    }
                     filterBtns[fi].classList.toggle('is-active', filterBtns[fi].dataset.historyFilter === activeFilter);
                 }
 
                 var shortcutBtns = document.querySelectorAll('[data-history-shortcut]');
                 for (var si = 0; si < shortcutBtns.length; si++) {
-                    shortcutBtns[si].addEventListener('click', function() {
-                        activeFilter = this.dataset.historyShortcut || 'all';
-                        var s = vscode.getState() || {};
-                        s.historyFilter = activeFilter;
-                        vscode.setState(s);
-                        for (var bi = 0; bi < filterBtns.length; bi++) {
-                            filterBtns[bi].classList.toggle('is-active', filterBtns[bi].dataset.historyFilter === activeFilter);
-                        }
-                        applyHistoryFilters();
-                    });
+                    if (shortcutBtns[si].getAttribute('data-history-bound') !== 'true') {
+                        shortcutBtns[si].addEventListener('click', function() {
+                            activeFilter = this.dataset.historyShortcut || 'all';
+                            var s = vscode.getState() || {};
+                            s.historyFilter = activeFilter;
+                            vscode.setState(s);
+                            for (var bi = 0; bi < filterBtns.length; bi++) {
+                                filterBtns[bi].classList.toggle('is-active', filterBtns[bi].dataset.historyFilter === activeFilter);
+                            }
+                            applyHistoryFilters();
+                        });
+                        shortcutBtns[si].setAttribute('data-history-bound', 'true');
+                    }
                 }
 
                 applyHistoryFilters();
@@ -744,6 +796,10 @@ export function getScript(): string {
                     vscode.postMessage({ command: 'clearActiveTracking' });
                     return;
                 }
+                if (target.closest('#clearQuotaHistory')) {
+                    vscode.postMessage({ command: 'clearQuotaHistory' });
+                    return;
+                }
 
                 // ── Privacy Mask Toggle ──
                 if (target.closest('#privacyToggle')) {
@@ -916,6 +972,8 @@ export function getScript(): string {
                 } else if (msg && msg.command === 'updateTabs') {
                     // ── Incremental refresh: update tab pane innerHTML without page reload ──
                     var tabs = msg.tabs;
+                    var visibleEocTabs = captureVisibleEocTabs();
+                    var changedTabKeys = [];
 
                     // Save scrollTop of inner scrollable elements before DOM swap
                     var scrollableSelectors = ['.raw-json', '.act-timeline', '.details-body', '.xray-body'];
@@ -933,8 +991,19 @@ export function getScript(): string {
 
                     for (var key in tabs) {
                         if (!tabs.hasOwnProperty(key)) continue;
+                        if (lastTabHtmls[key] === tabs[key]) { continue; }
                         var pane = document.getElementById('tab-' + key);
-                        if (pane) { pane.innerHTML = tabs[key]; }
+                        if (pane) {
+                            pane.innerHTML = tabs[key];
+                            lastTabHtmls[key] = tabs[key];
+                            changedTabKeys.push(key);
+                        }
+                    }
+
+                    for (var cti = 0; cti < changedTabKeys.length; cti++) {
+                        if (visibleEocTabs[changedTabKeys[cti]]) {
+                            restoreVisibleEoc(changedTabKeys[cti]);
+                        }
                     }
 
                     // !! CRITICAL: restore details IMMEDIATELY after innerHTML swap,
@@ -1016,7 +1085,15 @@ export function getScript(): string {
                 if (_eocObserver) { _eocObserver.disconnect(); }
                 _eocObserver = new IntersectionObserver(function(entries) {
                     for (var ei = 0; ei < entries.length; ei++) {
-                        entries[ei].target.classList.toggle('eoc-visible', entries[ei].isIntersecting);
+                        var isVisible = entries[ei].isIntersecting;
+                        entries[ei].target.classList.toggle('eoc-visible', isVisible);
+                        if (!isVisible) {
+                            entries[ei].target.classList.remove('eoc-no-transition');
+                        }
+                        var tabName = getTabNameFromNode(entries[ei].target);
+                        if (tabName) {
+                            eocVisibleTabs[tabName] = isVisible;
+                        }
                     }
                 }, { rootMargin: '0px', threshold: 0.1 });
                 var eocEls = document.querySelectorAll('.eoc-sentinel');

--- a/src/webview-settings-tab.ts
+++ b/src/webview-settings-tab.ts
@@ -177,6 +177,24 @@ export function buildSettingsContent(
             </div>
         </section>
 
+        <section class="stg-card" data-accent="quota">
+            <div class="stg-header">
+                <span class="stg-header-icon">${ICON.timeline}</span>
+                <h2>${tBi('Quota Timeline Tracking', '额度时间线追踪')}</h2>
+            </div>
+            <p class="raw-desc">${tBi(
+                'Tracks quota consumption against the official resetTime. Lightweight and always-on by default. Disable only if you never use the Quota Tracking tab.',
+                '基于官方 resetTime 追踪额度消耗。默认始终开启，性能开销极小。仅在完全不使用「额度追踪」标签页时才需关闭。',
+            )}</p>
+            <div class="toggle-group">
+                <label class="toggle-row">
+                    <input type="checkbox" id="toggleQuotaTracking" class="toggle-cb" ${tracker?.isEnabled() ? 'checked' : ''} />
+                    <span class="toggle-track"><span class="toggle-thumb"></span></span>
+                    <span>${tBi('Enable quota timeline tracking', '启用额度时间线追踪')}</span>
+                </label>
+            </div>
+        </section>
+
         <section class="stg-card" data-accent="poll">
             <div class="stg-header">
                 <span class="stg-header-icon">${ICON.clock}</span>

--- a/src/webview-styles.ts
+++ b/src/webview-styles.ts
@@ -95,6 +95,9 @@ export function getStyles(): string {
         .eoc-sentinel.eoc-visible {
             opacity: 1;
         }
+        .eoc-sentinel.eoc-no-transition {
+            transition: none;
+        }
         .eoc-sentinel::before,
         .eoc-sentinel::after {
             content: '';
@@ -3391,10 +3394,13 @@ export function getStyles(): string {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            flex-wrap: wrap;
             gap: var(--space-3);
+            margin-bottom: var(--space-3);
         }
         .card-header-row h2 { margin: 0; }
-        .card-header-row .qt-clear-active {
+        .card-header-row .qt-clear-active,
+        .card-header-row .qt-clear-history {
             flex-shrink: 0;
             font-size: 0.75em;
             padding: var(--space-1) var(--space-3);

--- a/src/webview-styles.ts
+++ b/src/webview-styles.ts
@@ -2090,11 +2090,67 @@ export function getStyles(): string {
         .tab-btn[data-color="yellow"] { --tab-c: 250, 204, 21; }
         .tab-btn[data-color="gray"]   { --tab-c: 148, 163, 184; }
 
+        .tab-bar-wrapper {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin-top: var(--space-2);
+            position: relative;
+        }
+
+        .tab-arrow {
+            appearance: none;
+            background: var(--color-surface);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: var(--radius-full, 9999px);
+            color: var(--color-text-dim);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 28px;
+            height: 28px;
+            flex-shrink: 0;
+            padding: 0;
+            opacity: 1;
+            pointer-events: auto;
+            transition: color 0.2s cubic-bezier(.4,0,.2,1), background 0.2s cubic-bezier(.4,0,.2,1), border-color 0.2s cubic-bezier(.4,0,.2,1), transform 0.15s cubic-bezier(.4,0,.2,1), opacity 0.25s cubic-bezier(.4,0,.2,1);
+            z-index: 2;
+        }
+        /* Fade-out state: keep layout space, disable interaction */
+        .tab-arrow.is-faded {
+            opacity: 0;
+            pointer-events: none;
+        }
+        .tab-arrow:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 2px var(--color-info);
+        }
+        .tab-arrow:active { transform: scale(0.93); }
+        @media (hover: hover) {
+            .tab-arrow:hover {
+                color: var(--color-text);
+                background: rgba(255,255,255,0.08);
+                border-color: rgba(255,255,255,0.15);
+            }
+        }
+        body.vscode-light .tab-arrow {
+            border-color: rgba(0,0,0,0.1);
+            background: rgba(255,255,255,0.7);
+        }
+        body.vscode-light .tab-arrow:hover {
+            background: rgba(0,0,0,0.05);
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .tab-arrow { transition: none; }
+        }
+
+
         .tab-bar {
             display: flex;
             gap: 4px;
             margin-bottom: 0;
-            margin-top: var(--space-2);
             background: var(--color-surface);
             border-radius: var(--radius-full, 9999px);
             padding: 4px;
@@ -2103,7 +2159,10 @@ export function getStyles(): string {
             overflow-y: hidden;
             scrollbar-width: none;
             -ms-overflow-style: none;
+            flex: 1;
+            min-width: 0;
         }
+
 
         /* Hide scrollbar on tab-bar */
         .tab-bar::-webkit-scrollbar { display: none; }
@@ -2622,28 +2681,55 @@ export function getStyles(): string {
             display: flex;
             flex-direction: column;
             gap: var(--space-2);
-            padding: var(--space-3);
-            border: 1px solid rgba(255,255,255,0.06);
+            padding: var(--space-3) var(--space-4, 20px);
+            border: 1px solid rgba(255,255,255,0.07);
             border-radius: var(--radius-lg);
             background:
-                linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015));
-            transition: border-color 0.2s cubic-bezier(.4,0,.2,1), box-shadow 0.2s cubic-bezier(.4,0,.2,1), transform 0.18s cubic-bezier(.4,0,.2,1);
+                linear-gradient(145deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.015) 100%);
+            transition: border-color 0.25s cubic-bezier(.4,0,.2,1), box-shadow 0.25s cubic-bezier(.4,0,.2,1), transform 0.2s cubic-bezier(.4,0,.2,1);
+            position: relative;
+            overflow: hidden;
+        }
+
+        /* ── Subtle top-left glow for depth ── */
+        .history-row::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 0;
+            width: 100%;
+            height: 3px;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.06) 30%, rgba(255,255,255,0.02) 70%, transparent);
+            border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+            pointer-events: none;
         }
 
         .history-row.is-current-session {
-            border-color: rgba(74, 222, 128, 0.22);
+            border-color: rgba(74, 222, 128, 0.25);
+            border-left: 3px solid rgba(74, 222, 128, 0.6);
             background:
-                linear-gradient(135deg, rgba(74, 222, 128, 0.06), transparent 45%),
-                linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015));
+                linear-gradient(135deg, rgba(74, 222, 128, 0.07), transparent 40%),
+                linear-gradient(145deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.015) 100%);
+        }
+
+        .history-row.is-current-session::before {
+            background: linear-gradient(90deg, rgba(74, 222, 128, 0.35), rgba(74, 222, 128, 0.08) 50%, transparent);
         }
 
         @media (hover: hover) {
             .history-row:hover {
-                border-color: rgba(255,255,255,0.15);
-                box-shadow: 0 6px 18px rgba(0,0,0,0.12);
-                transform: translateY(-1px);
+                border-color: rgba(255,255,255,0.18);
+                box-shadow:
+                    0 4px 12px rgba(0,0,0,0.12),
+                    0 12px 28px rgba(0,0,0,0.08);
+                transform: translateY(-2px);
+            }
+            .history-row.is-current-session:hover {
+                border-color: rgba(74, 222, 128, 0.35);
             }
         }
+
+
+
 
         .history-row-main {
             min-width: 0;
@@ -2659,20 +2745,21 @@ export function getStyles(): string {
         .history-row-title-wrap {
             display: flex;
             flex-direction: column;
-            gap: 1px;
+            gap: 2px;
             min-width: 0;
         }
 
         .history-row-title {
-            font-size: 0.92em;
+            font-size: 0.94em;
             font-weight: 700;
             color: var(--color-text);
-            line-height: 1.35;
+            line-height: 1.4;
             word-break: break-word;
             display: -webkit-box;
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
+            letter-spacing: 0.01em;
         }
 
         .history-row-subtitle {
@@ -2681,13 +2768,14 @@ export function getStyles(): string {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            opacity: 0.8;
         }
 
         .history-row-badges {
             display: flex;
             flex-wrap: wrap;
             justify-content: flex-end;
-            gap: 4px;
+            gap: 5px;
             flex-shrink: 0;
         }
 
@@ -2696,58 +2784,75 @@ export function getStyles(): string {
         .history-storage-row {
             display: flex;
             flex-wrap: wrap;
-            gap: 4px;
+            gap: 5px;
             margin-top: var(--space-1);
         }
 
         .history-row-foot {
             gap: var(--space-2);
+            padding-top: var(--space-1);
+            border-top: 1px solid rgba(255,255,255,0.04);
         }
 
         /* ── Inline credit/model display (compact) ── */
         .history-spotlight-grid {
             display: flex;
             gap: var(--space-2);
-            margin-top: var(--space-1);
+            margin-top: var(--space-2);
         }
 
         .history-spotlight-card {
             flex: 1 1 0;
-            border: 1px solid rgba(255,255,255,0.06);
+            border: 1px solid rgba(255,255,255,0.07);
             border-radius: var(--radius-md);
-            padding: var(--space-2);
+            padding: var(--space-2) var(--space-3);
             background: rgba(255,255,255,0.025);
+            transition: border-color 0.2s cubic-bezier(.4,0,.2,1), background 0.2s cubic-bezier(.4,0,.2,1);
         }
 
         .history-spotlight-card.is-credit {
             background:
-                linear-gradient(135deg, rgba(248, 113, 113, 0.10), transparent 55%),
+                linear-gradient(135deg, rgba(248, 113, 113, 0.12), transparent 55%),
                 rgba(255,255,255,0.025);
-            border-color: rgba(248, 113, 113, 0.12);
+            border-color: rgba(248, 113, 113, 0.15);
         }
 
         .history-spotlight-card.is-model {
             background:
-                linear-gradient(135deg, rgba(96, 165, 250, 0.10), transparent 55%),
+                linear-gradient(135deg, rgba(96, 165, 250, 0.12), transparent 55%),
                 rgba(255,255,255,0.025);
-            border-color: rgba(96, 165, 250, 0.12);
+            border-color: rgba(96, 165, 250, 0.15);
         }
 
         .history-spotlight-card.is-muted {
-            opacity: 0.5;
+            opacity: 0.45;
+        }
+
+        @media (hover: hover) {
+            .history-spotlight-card:hover {
+                border-color: rgba(255,255,255,0.15);
+                background: rgba(255,255,255,0.04);
+            }
+            .history-spotlight-card.is-credit:hover {
+                border-color: rgba(248, 113, 113, 0.25);
+            }
+            .history-spotlight-card.is-model:hover {
+                border-color: rgba(96, 165, 250, 0.25);
+            }
         }
 
         .history-spotlight-label {
             color: var(--color-text-dim);
             font-size: 0.68em;
             text-transform: uppercase;
-            letter-spacing: 0.06em;
+            letter-spacing: 0.08em;
+            font-weight: 600;
         }
 
         .history-spotlight-value {
-            margin-top: 2px;
+            margin-top: 3px;
             color: var(--color-text);
-            font-size: 0.92em;
+            font-size: 0.94em;
             font-weight: 700;
             line-height: 1.3;
         }
@@ -2764,6 +2869,7 @@ export function getStyles(): string {
 
         .history-foot-item.is-gm {
             color: #fcd34d;
+            font-weight: 600;
         }
 
         .history-row-actions {
@@ -2771,26 +2877,26 @@ export function getStyles(): string {
             flex-wrap: wrap;
             gap: var(--space-1);
             margin-top: auto;
-            padding-top: var(--space-1);
-            border-top: 1px solid rgba(255,255,255,0.04);
+            padding-top: var(--space-2);
+            border-top: 1px solid rgba(255,255,255,0.05);
         }
 
         .history-action-btn {
             appearance: none;
-            border: 1px solid rgba(255,255,255,0.08);
-            border-radius: var(--radius-sm);
-            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.09);
+            border-radius: var(--radius-md);
+            background: rgba(255,255,255,0.035);
             color: var(--color-text-dim);
             font: inherit;
             font-size: 0.72em;
             font-weight: 600;
-            padding: 5px 10px;
+            padding: 6px 12px;
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            gap: 4px;
+            gap: 5px;
             cursor: pointer;
-            transition: border-color 0.2s cubic-bezier(.4,0,.2,1), background-color 0.2s cubic-bezier(.4,0,.2,1), color 0.2s cubic-bezier(.4,0,.2,1), transform 0.15s cubic-bezier(.4,0,.2,1);
+            transition: border-color 0.2s cubic-bezier(.4,0,.2,1), background-color 0.2s cubic-bezier(.4,0,.2,1), color 0.2s cubic-bezier(.4,0,.2,1), transform 0.15s cubic-bezier(.4,0,.2,1), box-shadow 0.2s cubic-bezier(.4,0,.2,1);
             -webkit-tap-highlight-color: transparent;
         }
 
@@ -2801,8 +2907,8 @@ export function getStyles(): string {
 
         .history-action-btn.is-accent {
             color: #67e8f9;
-            border-color: rgba(34, 211, 238, 0.18);
-            background: rgba(34, 211, 238, 0.06);
+            border-color: rgba(34, 211, 238, 0.20);
+            background: rgba(34, 211, 238, 0.08);
         }
 
         .history-action-btn:focus {
@@ -2810,7 +2916,7 @@ export function getStyles(): string {
         }
 
         .history-action-btn:focus-visible {
-            box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.18);
+            box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.22);
         }
 
         .history-action-btn:active {
@@ -2819,26 +2925,87 @@ export function getStyles(): string {
 
         .history-action-btn:disabled {
             cursor: not-allowed;
-            opacity: 0.4;
+            opacity: 0.35;
             background: transparent;
         }
 
         @media (hover: hover) {
             .history-action-btn:hover {
                 color: var(--color-text);
-                border-color: rgba(255,255,255,0.18);
-                background: rgba(255,255,255,0.06);
+                border-color: rgba(255,255,255,0.20);
+                background: rgba(255,255,255,0.07);
+                transform: translateY(-1px);
+                box-shadow: 0 2px 6px rgba(0,0,0,0.1);
             }
             .history-action-btn.is-accent:hover {
-                border-color: rgba(34, 211, 238, 0.35);
-                background: rgba(34, 211, 238, 0.12);
+                border-color: rgba(34, 211, 238, 0.38);
+                background: rgba(34, 211, 238, 0.14);
             }
             .history-action-btn:disabled:hover {
                 color: var(--color-text-dim);
                 border-color: rgba(255,255,255,0.08);
                 background: transparent;
+                transform: none;
+                box-shadow: none;
             }
         }
+
+        /* ── Light Theme Overrides ── */
+        body.vscode-light .history-row {
+            border-color: rgba(0,0,0,0.08);
+            background: linear-gradient(145deg, rgba(255,255,255,0.7), rgba(248,250,252,0.5));
+            box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+        }
+        body.vscode-light .history-row::before {
+            background: linear-gradient(90deg, transparent, rgba(0,0,0,0.04) 30%, rgba(0,0,0,0.01) 70%, transparent);
+        }
+        body.vscode-light .history-row.is-current-session {
+            border-color: rgba(22, 163, 74, 0.2);
+            border-left-color: rgba(22, 163, 74, 0.5);
+            background: linear-gradient(135deg, rgba(22, 163, 74, 0.05), transparent 40%), linear-gradient(145deg, rgba(255,255,255,0.7), rgba(248,250,252,0.5));
+        }
+        body.vscode-light .history-row.is-current-session::before {
+            background: linear-gradient(90deg, rgba(22, 163, 74, 0.25), rgba(22, 163, 74, 0.06) 50%, transparent);
+        }
+        body.vscode-light .history-group-chip,
+        body.vscode-light .history-storage-badge,
+        body.vscode-light .history-badge,
+        body.vscode-light .history-meta-chip {
+            border-color: rgba(0,0,0,0.08);
+            background: rgba(0,0,0,0.035);
+        }
+        body.vscode-light .history-spotlight-card {
+            border-color: rgba(0,0,0,0.07);
+            background: rgba(0,0,0,0.02);
+        }
+        body.vscode-light .history-spotlight-card.is-credit {
+            background: linear-gradient(135deg, rgba(220, 38, 38, 0.06), transparent 55%), rgba(0,0,0,0.02);
+            border-color: rgba(220, 38, 38, 0.12);
+        }
+        body.vscode-light .history-spotlight-card.is-model {
+            background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), transparent 55%), rgba(0,0,0,0.02);
+            border-color: rgba(37, 99, 235, 0.12);
+        }
+        body.vscode-light .history-action-btn {
+            border-color: rgba(0,0,0,0.1);
+            background: rgba(0,0,0,0.025);
+        }
+        body.vscode-light .history-action-btn.is-accent {
+            color: #0891b2;
+            border-color: rgba(8, 145, 178, 0.2);
+            background: rgba(8, 145, 178, 0.06);
+        }
+        body.vscode-light .history-row-foot {
+            border-top-color: rgba(0,0,0,0.05);
+        }
+        body.vscode-light .history-row-actions {
+            border-top-color: rgba(0,0,0,0.06);
+        }
+        body.vscode-light .history-badge.is-workspace { color: #0891b2; border-color: rgba(8,145,178,0.2); background: rgba(8,145,178,0.08); }
+        body.vscode-light .history-badge.is-repo { color: #7c3aed; border-color: rgba(124,58,237,0.2); background: rgba(124,58,237,0.08); }
+        body.vscode-light .history-badge.is-current { color: #16a34a; border-color: rgba(22,163,74,0.2); background: rgba(22,163,74,0.08); }
+        body.vscode-light .history-badge.is-running { color: #d97706; border-color: rgba(217,119,6,0.2); background: rgba(217,119,6,0.08); }
+        body.vscode-light .history-foot-item.is-gm { color: #d97706; }
 
         @media (max-width: 920px) {
             .history-shortcuts-grid,
@@ -2878,6 +3045,8 @@ export function getStyles(): string {
                 transition: none;
             }
         }
+
+
 
         /* ─── Toggle Switch ────────────── */
         .toggle-group {

--- a/tests/activity-tracker.test.ts
+++ b/tests/activity-tracker.test.ts
@@ -39,6 +39,26 @@ function makePlannerStep(createdAt: string, response = '') {
     };
 }
 
+function makePlannerToolOnlyStep(createdAt: string, messageId: string) {
+    return {
+        type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+        metadata: {
+            createdAt,
+            generatorModel: 'MODEL_PLACEHOLDER_M37',
+        },
+        plannerResponse: {
+            messageId,
+            toolCalls: [
+                {
+                    id: 'tool-1',
+                    name: 'view_file',
+                    argumentsJson: '{}',
+                },
+            ],
+        },
+    };
+}
+
 function makeReasoningSummary(cascadeId: string, stepIndex: number, createdAt: string): GMSummary {
     return {
         conversations: [
@@ -140,6 +160,19 @@ function makeReasoningSummary(cascadeId: string, stepIndex: number, createdAt: s
         latestTokenBreakdown: [],
         stopReasonCounts: {},
     };
+}
+
+function makeReasoningSummaryWithPromptSnippet(
+    cascadeId: string,
+    stepIndex: number,
+    createdAt: string,
+    promptSnippet: string,
+    promptSource: 'none' | 'messagePrompts' | 'messageMetadata' = 'messagePrompts',
+): GMSummary {
+    const summary = makeReasoningSummary(cascadeId, stepIndex, createdAt);
+    summary.conversations[0].calls[0].promptSnippet = promptSnippet;
+    summary.conversations[0].calls[0].promptSource = promptSource;
+    return summary;
 }
 
 describe('ActivityTracker planner refresh', () => {
@@ -253,6 +286,58 @@ describe('ActivityTracker planner refresh', () => {
         expect(restoredUser?.modelBasis).toBe('step');
         expect(restoredUser?.gmInputTokens).toBeUndefined();
         expect(restoredUser?.gmExecutionId).toBeUndefined();
+    });
+
+    it('does not backfill step-based planner rows with GM prompt snippets when the planner response itself is empty', () => {
+        const tracker = new ActivityTracker() as any;
+        const cascadeId = 'conv-messageid';
+        const createdAt = '2026-03-27T13:18:53.982Z';
+        const plannerEvent = tracker._buildStepTimelineEvent(
+            makePlannerToolOnlyStep(createdAt, 'bot-fc2dab1b-0317-47cc-8b08-3384e2e70caf'),
+            406,
+            cascadeId,
+        );
+
+        tracker._upsertStepTimelineEvent(plannerEvent);
+        tracker.injectGMData(makeReasoningSummaryWithPromptSnippet(
+            cascadeId,
+            406,
+            createdAt,
+            'bot-fc2dab1b-0317-47cc-8b08-3384e2e70caf',
+        ));
+
+        const repairedEvent = tracker.getSummary().recentSteps.find((event: any) =>
+            event.cascadeId === cascadeId && event.stepIndex === 406
+        );
+        expect(repairedEvent?.aiResponse).toBeUndefined();
+        expect(repairedEvent?.detail).toContain('1 tool');
+        expect(repairedEvent?.gmPromptSnippet).toBe('bot-fc2dab1b-0317-47cc-8b08-3384e2e70caf');
+    });
+
+    it('keeps gm_virtual rows structural-only even when GM carries a readable prompt snippet', () => {
+        const tracker = new ActivityTracker() as any;
+        tracker._trajectories.set('conv-virtual', {
+            stepCount: 100,
+            processedIndex: 100,
+            dominantModel: 'Gemini 3.1 Pro (High)',
+            lastStatus: 'CASCADE_RUN_STATUS_IDLE',
+            requestedModel: '',
+            generatorModel: '',
+        });
+
+        tracker.injectGMData(makeReasoningSummaryWithPromptSnippet(
+            'conv-virtual',
+            120,
+            '2026-03-27T13:28:53.982Z',
+            '现在让我查看 buildOverallSummary 和 buildCalendarTabContent 函数。',
+        ));
+
+        const virtualEvent = tracker.getSummary().recentSteps.find((event: any) =>
+            event.cascadeId === 'conv-virtual' && event.source === 'gm_virtual'
+        );
+        expect(virtualEvent?.aiResponse).toBeUndefined();
+        expect(virtualEvent?.detail).toContain('stable#120');
+        expect(virtualEvent?.gmPromptSnippet).toBe('现在让我查看 buildOverallSummary 和 buildCalendarTabContent 函数。');
     });
 
     it('compacts duplicated persisted recent steps during restore so stale state self-heals on reload', () => {

--- a/tests/gm-tracker.test.ts
+++ b/tests/gm-tracker.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { GMSummary, GMTrackerState } from '../src/gm-tracker';
-import { filterGMSummaryByModels, GMTracker } from '../src/gm-tracker';
+import { filterGMSummaryByModels, GMTracker, pickPromptSnippet } from '../src/gm-tracker';
 import type { ModelConfig } from '../src/models';
 import type { QuotaSession } from '../src/quota-tracker';
 import { initI18nFromState } from '../src/i18n';
@@ -19,6 +19,27 @@ describe('filterGMSummaryByModels', () => {
     it('starts fresh instances in baseline mode so first install does not count historical GM calls', () => {
         const tracker = new GMTracker() as unknown as { _needsBaselineInit?: boolean };
         expect(tracker._needsBaselineInit).toBe(true);
+    });
+
+    it('prefers real prompt text over internal messageId fields when extracting prompt snippets', () => {
+        const snippet = pickPromptSnippet([
+            {
+                messageId: 'bot-fc2dab1b-0317-47cc-8b08-3384e2e70caf',
+                prompt: '现在让我查看 buildOverallSummary 和 buildCalendarTabContent 函数。',
+            },
+        ]);
+
+        expect(snippet).toBe('现在让我查看 buildOverallSummary 和 buildCalendarTabContent 函数。');
+    });
+
+    it('drops prompt snippets that are only internal bot messageIds', () => {
+        const snippet = pickPromptSnippet([
+            {
+                messageId: 'bot-fc2dab1b-0317-47cc-8b08-3384e2e70caf',
+            },
+        ]);
+
+        expect(snippet).toBe('');
     });
 
     it('keeps only the selected pool models in the archived snapshot', () => {


### PR DESCRIPTION
## 概述

本 PR 对 `main` 之上追加了 2 个提交，包含一轮较大的 WebView UI/UX 升级，以及随后一轮针对额度追踪、GM 摘要提取和增量刷新的修复补丁。

主要目标：
- 提升 Quota Tracking / Calendar / Sessions / Tab Bar 的可用性与视觉一致性
- 修正额度历史清理的作用范围
- 修复 GM prompt 摘要误提取内部 ID 的问题
- 修复增量轮询时「已到底」提示反复淡入，以及部分刷新后重复绑定监听的问题

## 主要改动

### UI / UX

- 日历汇总区新增「月度 / 全部」切换
- Tab 栏新增左右箭头导航
- Quota Tracking 关闭时提供更明确的空状态提示和跳转入口
- 会话卡片视觉升级，统一按钮与卡片交互反馈
- 在「已完成会话」标题旁新增独立清理按钮，并补充标题行留白，避免与下方汇总内容贴紧

### 行为修复

- 历史清理按钮只清除归档历史，不再误清 active tracking state
- GM prompt 摘要提取过滤 `bot-*`、`toolu_*`、`req_vrtx_*`、`session-*` 等内部标识
- planner / gm_virtual 时间线保持结构化展示，不回填伪 AI 回复
- `updateTabs` 增量刷新跳过未变化 tab，减少不必要的 `innerHTML` 替换
- 保留已可见的 end-of-content sentinel 状态，避免轮询刷新时反复淡入
- 为 `<details>` 状态恢复和会话筛选控件补充幂等监听保护，避免重复绑定
- 移除会话卡片在轮询时反复触发的入场动画

### 文档与测试

- 更新 `CHANGELOG.md`
- 补充 `activity-tracker` / `gm-tracker` 回归测试用例，覆盖 GM prompt 摘要与结构化时间线场景

## 重点文件

- `src/webview-calendar-tab.ts`
- `src/webview-history-tab.ts`
- `src/webview-script.ts`
- `src/webview-styles.ts`
- `src/activity-tracker.ts`
- `src/gm-tracker.ts`
- `CHANGELOG.md`

## 建议验收点

- Quota Tracking 中 active / completed 两块的按钮布局、间距和清理行为
- 轮询刷新后「已到底」提示不再重复淡入
- Sessions 搜索、筛选、`<details>` 展开状态在刷新后仍正常
- GM 时间线不再出现内部 messageId / requestId 作为可读摘要
- Calendar 月度 / 全部切换与 Tab 箭头导航交互正常