### PR TITLE
fix: Antigravity 1.22.2+ 更新后插件连接旧 LS 导致实时数据追踪失效

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # 变更日志 / Changelog
 
+## [1.14.10] - 2026-04-09
+
+### 🐛 Fixed / 修复
+
+- **🔥 Stale LS Connection After Antigravity Update — workspace_id Architecture Change / Antigravity 更新后连接旧 LS — workspace_id 架构变更**: Fixed a critical bug where the context monitor stopped tracking real-time data after Antigravity updated to v1.22.2+. Root cause: Antigravity 1.22.2 changed its Language Server (LS) architecture from per-workspace processes (with `--workspace_id` argument) to a single shared LS process (without `--workspace_id`). When the IDE updated, the old LS process (with workspace_id) remained alive alongside the new shared LS (without workspace_id). The plugin's `selectMatchingProcessLine()` prioritized exact workspace_id matches, so it **always connected to the old stale LS** — which responded to RPC calls but returned frozen data (wrong step counts, no RUNNING status, missing new conversations). Fix: reversed the selection priority in `selectMatchingProcessLine()` — processes WITHOUT `--workspace_id` (new shared LS architecture) are now preferred over those WITH workspace_id (legacy per-workspace LS). Falls back to workspace_id matching only when no new-style LS exists, maintaining backward compatibility.
+  修复一个严重 Bug：Antigravity 更新至 v1.22.2+ 后，上下文监控完全停止实时数据追踪。根因：Antigravity 1.22.2 将语言服务器（LS）从按工作区独立进程（带 `--workspace_id` 参数）改为单一共享 LS（不带 `--workspace_id`）。IDE 更新后，旧 LS 进程（带 workspace_id）仍然存活，与新 LS 共存。插件的 `selectMatchingProcessLine()` 优先精确匹配 workspace_id，因此**始终连接到旧的僵尸 LS**——该进程能正常响应 RPC 调用，但返回的数据完全过时（步数冻结、无 RUNNING 状态、新对话不可见）。修复：反转 `selectMatchingProcessLine()` 的选择优先级——无 `--workspace_id` 的进程（新架构共享 LS）现在优先于有 workspace_id 的进程（旧架构按工作区 LS）。当无新架构 LS 时仍回退到 workspace_id 匹配，保持向后兼容。
+
+- **Periodic LS PID Re-validation / 定期 LS PID 重校验**: Added a periodic PID re-validation mechanism to the polling loop. Every ~30 seconds, the plugin re-runs `discoverLanguageServer()` and compares the current LS PID with the cached PID. If they differ (e.g., Antigravity spawned a new LS after a silent update), the plugin automatically reconnects without requiring a window reload.
+  轮询循环中新增定期 PID 重校验机制。每约 30 秒自动重新发现 LS 并对比 PID，若 PID 已变（如 Antigravity 静默更新后生成了新 LS），插件自动重连，无需手动刷新窗口。
+
+- **Staleness Heuristic for Zombie LS Detection / 僵尸 LS 检测启发式**: Added a secondary defense layer: if the plugin is tracking a conversation but the LS reports all conversations as IDLE for 4+ consecutive polls, the plugin assumes the LS is stale and forces a re-discovery attempt. This catches edge cases where the PID doesn't change but the LS data becomes outdated.
+  新增二级防御：当插件正在追踪对话但 LS 连续 4+ 轮报告所有对话为 IDLE 时，插件判定 LS 已过时并强制重新发现。捕捉 PID 未变但数据已过期的边缘情况。
+
+- **New Conversation First-Poll Delay / 新对话首轮延迟**: Fixed a UX issue where starting a new conversation required two poll cycles before data appeared. Root cause: the new-trajectory detection priority (`Priority 3`) was gated by `!trackedCascadeId` — it only switched to new conversations when NO cascade was being tracked. Since the plugin always has a sticky tracked cascade, new conversations were silently ignored on their first appearance. Fix: removed the `!trackedCascadeId` guard so new trajectories immediately take priority over sticky tracking.
+  修复新对话需要两个轮询周期才能显示数据的体验问题。根因：新对话检测（Priority 3）受 `!trackedCascadeId` 条件限制——只有在没有任何被追踪对话时才会切换到新对话。由于插件始终有一个粘性追踪的对话，新对话在首次出现时被静默忽略。修复：移除 `!trackedCascadeId` 限制，使新对话立即获得优先级。
+
+### 📊 Stats / 统计
+
+- **Files changed**: 2 (`discovery.ts`, `extension.ts`)
+- **TypeScript compile**: Zero errors
+
+---
+
 ## [1.14.9] - 2026-04-08
 
 ### ✨ Improved / 改进

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -126,20 +126,47 @@ export function extractWorkspaceId(line: string): string | null {
 
 /**
  * Select the LS process line for the current workspace.
- * Without a workspace URI, falls back to the first discovered LS.
- * With a workspace URI, prefers an exact workspace_id match but falls back
- * to the first discovered LS if no match exists. This handles the common
- * case where a single shared LS serves multiple VS Code windows/workspaces.
+ *
+ * PRIORITY ORDER (Antigravity 1.22.2+ compatibility):
+ * 1. Processes WITHOUT --workspace_id → new shared LS architecture (preferred)
+ * 2. Processes WITH matching workspace_id → old per-workspace LS (fallback)
+ * 3. First discovered LS → last resort
+ *
+ * BUG FIX: Antigravity 1.22.2+ launches a single shared LS without
+ * --workspace_id. When an old LS (with workspace_id) is still alive,
+ * the previous logic always picked the old stale LS because it had a
+ * matching workspace_id. The new shared LS (without workspace_id) is
+ * the active instance and should be preferred.
  */
 export function selectMatchingProcessLine(lines: readonly string[], workspaceUri?: string): string | null {
     if (lines.length === 0) {
         return null;
     }
-    if (!workspaceUri) {
+    if (lines.length === 1) {
         return lines[0];
     }
-    const expectedWorkspaceId = buildExpectedWorkspaceId(workspaceUri);
-    return lines.find(line => extractWorkspaceId(line) === expectedWorkspaceId) ?? lines[0];
+
+    // Separate processes into new-style (no workspace_id) and old-style (has workspace_id)
+    const newStyleLines = lines.filter(line => extractWorkspaceId(line) === null);
+    const oldStyleLines = lines.filter(line => extractWorkspaceId(line) !== null);
+
+    // Priority 1: Prefer new-style shared LS (no workspace_id)
+    // These are Antigravity 1.22.2+ processes — the active instance.
+    if (newStyleLines.length > 0) {
+        return newStyleLines[0];
+    }
+
+    // Priority 2: Old-style LS — match by workspace_id if available
+    if (workspaceUri && oldStyleLines.length > 0) {
+        const expectedWorkspaceId = buildExpectedWorkspaceId(workspaceUri);
+        const match = oldStyleLines.find(line => extractWorkspaceId(line) === expectedWorkspaceId);
+        if (match) {
+            return match;
+        }
+    }
+
+    // Priority 3: First discovered line
+    return lines[0];
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,19 @@ let lastKnownModel = '';
 // ─── Exponential Backoff State ────────────────────────────────────────────────
 let baseIntervalMs = 5000;
 let currentIntervalMs = 5000;
+
+// ─── LS PID Revalidation ──────────────────────────────────────────────────────
+// BUG FIX: When Antigravity updates its LS, the old process may stay alive and
+// keep responding to RPC calls with stale data. The plugin caches the old
+// connection and never discovers the new LS. This counter forces periodic
+// re-discovery to compare PIDs and detect stale connections.
+let lsRevalidationCounter = 0;
+/** Re-validate LS PID every N poll cycles. At 5s polling = ~30s. */
+const LS_REVALIDATION_INTERVAL = 6;
+/** Tracks consecutive polls where workspace has 0 RUNNING conversations. */
+let consecutiveIdlePolls = 0;
+/** If we're tracking a cascade and it stays IDLE for this many polls, assume stale LS. */
+const STALE_LS_IDLE_THRESHOLD = 4;
 let consecutiveFailures = 0;
 
 // AbortController — cancel in-flight RPC requests on extension deactivate.
@@ -550,19 +563,21 @@ async function pollContextUsage(): Promise<void> {
         const workspaceUri = getWorkspaceUri();
         const normalizedWs = workspaceUri ? normalizeUri(workspaceUri) : '(none)';
 
-        // 2. Discover LS (with caching)
+        // 2. Discover LS (with caching + periodic PID revalidation)
         if (!lsInfo) {
             log('Discovering language server...');
             statusBar.showInitializing();
             lsInfo = await discoverLanguageServer(workspaceUri, abortController.signal);
             cachedLsInfo = lsInfo;
+            lsRevalidationCounter = 0;
+            consecutiveIdlePolls = 0;
 
             if (!lsInfo) {
                 handleLsFailure('LS not found', true);
                 return;
             }
             resetBackoff();
-            log(`LS found: port=${lsInfo.port}, tls=${lsInfo.useTls}`);
+            log(`LS found: pid=${lsInfo.pid} port=${lsInfo.port}, tls=${lsInfo.useTls}`);
 
             // Dynamically update model display names from GetUserStatus
             try {
@@ -586,6 +601,45 @@ async function pollContextUsage(): Promise<void> {
                 }
             } catch { /* Silent degradation */ }
         } else {
+            // ─── Periodic LS PID Revalidation ─────────────────────────────────
+            // BUG FIX: When Antigravity updates, a new LS may start while the old
+            // one is still alive and responding with stale data. This periodic
+            // check detects PID changes and forces reconnection.
+            lsRevalidationCounter++;
+            if (lsRevalidationCounter >= LS_REVALIDATION_INTERVAL) {
+                lsRevalidationCounter = 0;
+                try {
+                    const freshLs = await discoverLanguageServer(workspaceUri, abortController.signal);
+                    if (freshLs && freshLs.pid !== lsInfo.pid) {
+                        log(`⚠ LS PID changed: ${lsInfo.pid} → ${freshLs.pid} (port: ${lsInfo.port} → ${freshLs.port}). Reconnecting to new LS.`);
+                        lsInfo = freshLs;
+                        cachedLsInfo = freshLs;
+                        consecutiveIdlePolls = 0;
+                        // Re-fetch user status from new LS
+                        try {
+                            const fullStatus = await fetchFullUserStatus(lsInfo, abortController.signal);
+                            if (fullStatus.configs.length > 0) {
+                                updateModelDisplayNames(fullStatus.configs);
+                                cachedModelConfigs = fullStatus.configs;
+                                statusBar.setModelConfigs(fullStatus.configs);
+                                quotaTracker.processUpdate(fullStatus.configs);
+                                checkQuotaNotification(fullStatus.configs);
+                            }
+                            if (fullStatus.userInfo) {
+                                cachedUserInfo = fullStatus.userInfo;
+                                statusBar.setPlanName(fullStatus.userInfo.planName, fullStatus.userInfo.userTierName);
+                                durableGlobalState.update('cachedModelConfigs', cachedModelConfigs);
+                                durableGlobalState.update('cachedPlanName', fullStatus.userInfo.planName);
+                                durableGlobalState.update('cachedTierName', fullStatus.userInfo.userTierName);
+                            }
+                        } catch { /* Silent */ }
+                    }
+                } catch {
+                    // Discovery failed — keep using current connection
+                    log('LS revalidation: discovery failed, keeping current connection');
+                }
+            }
+
             // Periodic refresh of user status (every STATUS_REFRESH_INTERVAL polls)
             statusPollCount++;
             if (statusPollCount >= STATUS_REFRESH_INTERVAL) {
@@ -660,6 +714,36 @@ async function pollContextUsage(): Promise<void> {
 
         log(`Trajectories: ${trajectories.length} total, ${qualifiedTrajectories.length} qualified in ws, ${qualifiedRunning.length} running in ws`);
 
+        // ─── Staleness Heuristic ───────────────────────────────────────────
+        // BUG FIX: If we're tracking a RUNNING cascade but LS reports it as IDLE
+        // for too many consecutive polls, the LS is probably stale. Force re-discovery.
+        if (qualifiedRunning.length === 0 && trackedCascadeId) {
+            consecutiveIdlePolls++;
+            if (consecutiveIdlePolls >= STALE_LS_IDLE_THRESHOLD) {
+                log(`⚠ Staleness detected: tracked cascade ${trackedCascadeId.substring(0, 8)} has been IDLE for ${consecutiveIdlePolls} consecutive polls. Forcing LS re-discovery.`);
+                consecutiveIdlePolls = 0;
+                try {
+                    const freshLs = await discoverLanguageServer(workspaceUri, abortController.signal);
+                    if (freshLs && freshLs.pid !== lsInfo.pid) {
+                        log(`⚠ Stale LS confirmed: PID ${lsInfo.pid} → ${freshLs.pid}. Reconnecting.`);
+                        lsInfo = freshLs;
+                        cachedLsInfo = freshLs;
+                        lsRevalidationCounter = 0;
+                        // Re-fetch trajectories from the new LS
+                        trajectories = await getAllTrajectories(lsInfo, abortController.signal);
+                        lastTrajectories = trajectories;
+                    } else if (freshLs) {
+                        log('LS PID unchanged — staleness was a false alarm (cascade genuinely IDLE)');
+                    }
+                } catch {
+                    log('Staleness re-discovery failed, keeping current connection');
+                }
+            }
+        } else {
+            consecutiveIdlePolls = 0;
+        }
+
+
         // --- Priority 1: RUNNING status detection ---
         if (qualifiedRunning.length > 0) {
             const currentStillRunning = qualifiedRunning.find(t => t.cascadeId === trackedCascadeId);
@@ -702,7 +786,10 @@ async function pollContextUsage(): Promise<void> {
         }
 
         // --- Priority 3: New trajectory detection ---
-        if (!newCandidateId && firstPollDone && !trackedCascadeId) {
+        // Switch to new conversations immediately — even if we're already tracking
+        // another cascade. Without this, a new conversation would be ignored on
+        // its first poll cycle, causing a visible one-cycle delay before data appears.
+        if (!newCandidateId && firstPollDone) {
             const newlyCreated = qualifiedTrajectories.filter(t => !previousTrajectoryIds.has(t.cascadeId));
             if (newlyCreated.length > 0) {
                 newCandidateId = newlyCreated[0].cascadeId;


### PR DESCRIPTION
### 问题描述

Antigravity 更新至 v1.22.2 后，上下文监控插件**完全停止实时数据追踪**：

- 启动后首次能获取数据（warm-up 阶段正常）
- 之后数据完全冻结：步数不再增长、状态永远显示 IDLE、新对话不可见
- 必须手动刷新窗口（Reload Window）才能恢复，但下一轮又会冻结

### 根因分析

#### Antigravity 1.22.2 的 LS 架构变更

Antigravity 1.22.2 将 Language Server 从**按工作区独立进程**改为**单一共享进程**：

```
旧版 ≤1.21.x：每个工作区独立 LS → 启动参数带 --workspace_id file_e_3A_xxx
新版 ≥1.22.2：单一共享 LS       → 启动参数不再包含 --workspace_id
```

#### 双 LS 共存导致连接错误

更新后旧 LS 进程**未被清理**，与新 LS 同时存活：

```
PID=29808 (新 LS) → 无 --workspace_id → 13 对话, 1 RUNNING ✅ 活跃数据源
PID=14792 (旧 LS) → 有 --workspace_id → 10 对话, 0 RUNNING ❌ 僵尸进程
```

插件的 `selectMatchingProcessLine()` **优先精确匹配 workspace_id**：

```typescript
// 旧逻辑（v1.14.9）
const expectedWorkspaceId = buildExpectedWorkspaceId(workspaceUri);
return lines.find(line => extractWorkspaceId(line) === expectedWorkspaceId) ?? lines[0];
//             ↑ 旧 LS 有匹配的 workspace_id → 永远选中旧 LS！
```

旧 LS 能正常响应 RPC 调用（不报错），但返回的数据完全过时——插件"以为一切正常"，实际上连接的是僵尸进程。

### 修复内容

#### 1. LS 选择优先级反转（`discovery.ts`）

```typescript
// 新逻辑（v1.14.10）
// Priority 1: 无 workspace_id → 新版共享 LS（首选）
const newStyleLines = lines.filter(line => extractWorkspaceId(line) === null);
if (newStyleLines.length > 0) return newStyleLines[0];

// Priority 2: 有匹配 workspace_id → 旧版 LS（兼容回退）
// Priority 3: 第一个发现的进程 → 最终兜底
```

向后兼容：旧版 Antigravity（所有 LS 都有 workspace_id）走 Priority 2，行为不变。

#### 2. PID 定期重校验（`extension.ts`）

每 ~30 秒自动重新发现 LS 并比较 PID，PID 变化时自动重连：

```
每 6 次轮询 → discoverLanguageServer() → PID 变了？ → 自动切换
```

#### 3. 僵尸 LS 启发式检测（`extension.ts`）

当连续 4 轮工作区内所有对话均为 IDLE（但有 trackedCascade），触发重新发现：

```
连续 4 轮 RUNNING=0 + 有 trackedCascadeId → 强制 re-discovery
```

#### 4. 新对话首轮检测（`extension.ts`）

移除 `!trackedCascadeId` 限制，新对话出现时立即切换：

```diff
- if (!newCandidateId && firstPollDone && !trackedCascadeId) {
+ if (!newCandidateId && firstPollDone) {
```

### 测试验证

- ✅ 双 LS 共存时正确选择新 LS
- ✅ 实时 stepCount 变化被捕获
- ✅ RUNNING 状态被正确检测
- ✅ 新对话首轮即可显示数据
- ✅ 旧版 Antigravity（有 workspace_id）行为不变

### 变更文件

| 文件 | 变更 |
|---|---|
| `src/discovery.ts` | `selectMatchingProcessLine()` 优先级反转 |
| `src/extension.ts` | PID 重校验 + 僵尸检测 + 新对话首轮检测 |
| `CHANGELOG.md` | v1.14.10 变更记录 |

---
