### PR TITLE
修复当账号为Tree时，显示的是pro或ultra错误显示，新增检测环境版本信息

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # 变更日志 / Changelog
 
+## [Unreleased]
+
+### 🐛 Fixed / 修复
+
+- **Stale Plan Tier Label in Status Bar Tooltip / 状态栏悬浮计划层级标签残留**: Fixed a UI cache bug where the status bar tooltip could keep showing an old secondary tier label such as `Google AI Ultra` even after Antigravity stopped returning `userTierName`. Root cause: `StatusBarManager.setPlanName()` only updated the cached tier name when the new value was truthy, so an empty latest tier never cleared the old in-memory value. Fix: the cached tier label is now always overwritten, and empty values explicitly clear the stale tier suffix. This keeps the tooltip aligned with the latest live `GetUserStatus` result.
+  修复状态栏悬浮提示中的计划层级标签残留问题：即使 Antigravity 已不再返回 `userTierName`，提示里仍可能继续显示旧的二级标签，例如 `Google AI Ultra`。根因：`StatusBarManager.setPlanName()` 只有在新 `tierName` 为真值时才更新缓存，导致最新值为空时，旧的内存缓存不会被清掉。修复后，计划层级缓存每次都会被覆盖，空值会显式清空旧后缀，使悬浮提示与最新的 `GetUserStatus` 实时结果保持一致。
+
+### 🧪 Tests / 测试
+
+- **Status Bar Tier Cache Regression Test / 状态栏层级缓存回归测试**: Added a regression test covering the exact transition from `Pro · Google AI Ultra` to `Pro` when the latest tier name becomes empty.
+  新增状态栏层级缓存回归测试，覆盖 `Pro · Google AI Ultra` 在最新 tier 为空后正确回落为 `Pro` 的场景。
+
+---
+
 ## [1.15.0] - 2026-04-10
 
 ### 🐛 Fixed / 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### ✨ Improved / 改进
+
+- **Stable Current Plan Display in Status Bar Hover / 状态栏悬浮计划显示稳定化**: The plan row in the status bar hover now prefers the current cloud-verified plan when available, instead of relying only on the LS compatibility label. If cloud verification is temporarily unavailable, the extension keeps the last verified plan visible instead of immediately snapping back to the LS fallback value. The hover tooltip also shows a source label (`Cloud verified`, `Cloud verified (cached)`, or `LS fallback`) so the displayed membership state is explicit.
+  状态栏悬浮面板中的计划行现在会优先显示当前云端校验过的计划，而不是只依赖 LS 的兼容层标签。若本轮暂时无法完成云端校验，扩展会保留上次成功校验过的计划显示，不再立刻跳回 LS fallback 值。悬浮提示同时新增来源标记（`Cloud verified`、`Cloud verified (cached)`、`LS fallback`），让当前会员状态口径可见。
+
+- **Profile Plan Messaging / Profile 计划说明增强**: The Profile tab now explains whether the displayed plan is live cloud data, cached cloud truth, or an LS compatibility fallback, reducing confusion when plan labels differ.
+  Profile 页现在会明确说明当前展示的是实时云端计划、缓存的云端真值，还是 LS 兼容层 fallback，避免计划标签不一致时产生误解。
+
 ### 🐛 Fixed / 修复
 
 - **Stale Plan Tier Label in Status Bar Tooltip / 状态栏悬浮计划层级标签残留**: Fixed a UI cache bug where the status bar tooltip could keep showing an old secondary tier label such as `Google AI Ultra` even after Antigravity stopped returning `userTierName`. Root cause: `StatusBarManager.setPlanName()` only updated the cached tier name when the new value was truthy, so an empty latest tier never cleared the old in-memory value. Fix: the cached tier label is now always overwritten, and empty values explicitly clear the stale tier suffix. This keeps the tooltip aligned with the latest live `GetUserStatus` result.
@@ -11,6 +19,9 @@
 
 - **Status Bar Tier Cache Regression Test / 状态栏层级缓存回归测试**: Added a regression test covering the exact transition from `Pro · Google AI Ultra` to `Pro` when the latest tier name becomes empty.
   新增状态栏层级缓存回归测试，覆盖 `Pro · Google AI Ultra` 在最新 tier 为空后正确回落为 `Pro` 的场景。
+
+- **Cloud Plan Stability Regression Tests / 云端计划稳定性回归测试**: Added coverage for preserving the last cloud-verified plan when a later poll degrades to LS fallback, plus tooltip source-label rendering.
+  新增云端计划稳定性回归测试，覆盖“后续轮询退回 LS 时仍保留上次云端真值”和悬浮提示来源标记渲染两类场景。
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 变更日志 / Changelog
 
-## [Unreleased]
+## [1.15.1] - 2026-04-13
 
 ### ✨ Improved / 改进
 
@@ -10,10 +10,17 @@
 - **Profile Plan Messaging / Profile 计划说明增强**: The Profile tab now explains whether the displayed plan is live cloud data, cached cloud truth, or an LS compatibility fallback, reducing confusion when plan labels differ.
   Profile 页现在会明确说明当前展示的是实时云端计划、缓存的云端真值，还是 LS 兼容层 fallback，避免计划标签不一致时产生误解。
 
+
+- **Environment Info Card in Profile Tab / 个人面板新增环境信息卡**: Added a new "Environment" section in the Profile tab displaying 5 diagnostic fields mined from LS `GetUnleashData` context and Cloud endpoints: IDE version (`ideVersion`), installation ID (`installationId`), region code (`regionCode` from Cloud `fetchUserInfo`), Anthropic model access flag, and custom GCP Cloud AI Companion project status. These help users quickly verify their environment configuration during troubleshooting without needing to run diagnostic scripts.
+  个人面板新增`环境`卡片，展示从 LS `GetUnleashData` 上下文和 Cloud 端点挖掘的 5 个诊断字段：IDE 版本、安装 ID、地区代码（来自 Cloud `fetchUserInfo`）、Anthropic 模型访问权限和自定义 GCP Cloud AI Companion 项目状态。帮助用户在排障时快速确认环境配置，无需手动运行诊断脚本。
+
 ### 🐛 Fixed / 修复
 
 - **Stale Plan Tier Label in Status Bar Tooltip / 状态栏悬浮计划层级标签残留**: Fixed a UI cache bug where the status bar tooltip could keep showing an old secondary tier label such as `Google AI Ultra` even after Antigravity stopped returning `userTierName`. Root cause: `StatusBarManager.setPlanName()` only updated the cached tier name when the new value was truthy, so an empty latest tier never cleared the old in-memory value. Fix: the cached tier label is now always overwritten, and empty values explicitly clear the stale tier suffix. This keeps the tooltip aligned with the latest live `GetUserStatus` result.
   修复状态栏悬浮提示中的计划层级标签残留问题：即使 Antigravity 已不再返回 `userTierName`，提示里仍可能继续显示旧的二级标签，例如 `Google AI Ultra`。根因：`StatusBarManager.setPlanName()` 只有在新 `tierName` 为真值时才更新缓存，导致最新值为空时，旧的内存缓存不会被清掉。修复后，计划层级缓存每次都会被覆盖，空值会显式清空旧后缀，使悬浮提示与最新的 `GetUserStatus` 实时结果保持一致。
+
+- **Cloud Tier "Standard" Mislabel for Paid Plans / 云端层级对付费计划误标为"Standard"**: Fixed a misleading plan display where the status bar and Profile tab showed "Standard" for paid Gemini subscribers. Root cause: Google's cloud API returns `standard-tier` as the tier ID for the paid plan ("Gemini Code Assist"), but `mapCloudTierToDisplayPlan()` hardcoded the display name to `"Standard"` for any tier containing "standard" in its ID. Since Google's `standard-tier` is actually the premium paid plan (description: "Unlimited coding assistant with the most powerful Gemini models"), displayying "Standard" confused users into thinking they were on a lower-tier plan. Fix: `mapCloudTierToDisplayPlan()` now uses the cloud-provided `tierName` (e.g., "Gemini Code Assist") as the display name for `standard`, `pro`, and `ultra` tier IDs instead of hardcoding generic labels. Free tier retains the hardcoded "Free" label. Also added a future-proof `ultra` tier branch (`CLOUD_TIER_ULTRA`) with a gold badge style in the Profile tab.
+  修复状态栏和个人面板对付费 Gemini 订阅用户误显示"Standard"的问题。根因：Google 云端 API 对付费计划返回的 tier ID 是 `standard-tier`，但 `mapCloudTierToDisplayPlan()` 把所有 ID 含 "standard" 的 tier 写死显示为 `"Standard"`。事实上 `standard-tier` 是 Google 新体系中的付费计划统称（description 为"Unlimited coding assistant with the most powerful Gemini models"），显示"Standard"会让用户误以为自己在低级计划上。修复后，`standard`、`pro`、`ultra` 分支现在使用云端返回的 `tierName`（如"Gemini Code Assist"）作为显示名，不再写死通用标签；Free 分支保持原样。同时新增 `ultra` 预留分支（`CLOUD_TIER_ULTRA`）和 Profile 面板金色徽章样式。
 
 ### 🧪 Tests / 测试
 
@@ -22,6 +29,9 @@
 
 - **Cloud Plan Stability Regression Tests / 云端计划稳定性回归测试**: Added coverage for preserving the last cloud-verified plan when a later poll degrades to LS fallback, plus tooltip source-label rendering.
   新增云端计划稳定性回归测试，覆盖“后续轮询退回 LS 时仍保留上次云端真值”和悬浮提示来源标记渲染两类场景。
+
+- **Cloud Tier Name Display Test Update / 云端层级名称显示测试更新**: Updated the `mapCloudTierToDisplayPlan` test for `standard-tier` to verify it now uses the cloud-provided tier name ("Gemini Code Assist") instead of the hardcoded "Standard" label.
+  更新 `mapCloudTierToDisplayPlan` 对 `standard-tier` 的测试：现在验证使用云端返回的 tier name（"Gemini Code Assist"）而非硬编码的 "Standard" 标签。
 
 ---
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -15,6 +15,7 @@ antigravity-context-monitor/
 │   ├── discovery.ts              # Language Server 进程发现（跨平台）
 │   ├── rpc-client.ts             # Connect-RPC 通用调用器
 │   ├── tracker.ts                # Token 计算、会话数据获取、用户状态查询
+│   ├── cloud-plan.ts             # 云端计划查询与稳定缓存（计划真值优先级控制）
 │   ├── models.ts                 # 模型配置、上下文限额、显示名称、跨语言归一化
 │   ├── constants.ts              # 全局常量（Step 类型、阈值、限制值）
 │   ├── statusbar.ts              # 状态栏 UI（StatusBarManager）
@@ -36,7 +37,7 @@ antigravity-context-monitor/
 │   ├── webview-monitor-tab.ts    # Monitor 标签页 HTML（支持 GM 快照回退）
 │   ├── webview-models-tab.ts     # Models 标签页 HTML（默认模型 + 模型配额 + 模型信息）
 │   ├── webview-settings-tab.ts   # Settings 标签页 HTML（含持久化状态诊断 + 界面提示偏好）
-│   ├── webview-profile-tab.ts    # Profile 标签页 HTML（账户 / 计划限制 / 功能与团队）
+│   ├── webview-profile-tab.ts    # Profile 标签页 HTML（账户 / 计划限制 / 功能与团队 / 计划来源说明）
 │   ├── webview-history-tab.ts    # Quota Tracking 标签页 HTML
 │   ├── webview-chat-history-tab.ts # Sessions 标签页 HTML（会话目录 — 全量对话列表 + 筛选）
 │   ├── activity-panel.ts         # GM Data 统一标签页 HTML（Activity + GM 数据）
@@ -135,15 +136,29 @@ Core data processing module: trajectory listing, token computation, context usag
 | `getTrajectoryTokenUsage()` | 分批获取步骤（50 步/批，5 并发组）+ 调用 `processSteps()` |
 | `processSteps()` | 纯函数：步骤数组 → Token 统计（checkpoint 精确值 + 文本估算增量） |
 | `getContextUsage()` | 组装 `ContextUsage` 对象供 UI 层使用 |
-| `fetchFullUserStatus()` | 获取完整用户状态（模型配置、计划信息、Feature Flags） |
+| `fetchFullUserStatus()` | 获取完整用户状态（模型配置、计划信息、Feature Flags），并在可能时合并云端校验过的计划显示 |
+
+---
+
+### ☁️ cloud-plan.ts — 云端计划真值与稳定缓存
+
+负责补充计划显示这条数据链，让 UI 不只依赖 LS 兼容层标签。
+
+Provides the plan-verification path so the UI does not rely solely on LS compatibility labels.
+
+| 函数 / Function | 说明 / Description |
+|---|---|
+| `fetchCloudPlanInfo()` | 查询当前账号的云端计划，并做短期缓存 |
+| `discoverCloudTokens()` | 优先当前窗口 LS，再尝试其他候选 token，降低抓取抖动 |
+| stale cloud reuse | 云端临时失败时复用最近一次成功结果，避免 hover 中的计划行来回跳变 |
 
 ---
 
 ### 🤖 models.ts — 模型配置与归一化
 
-模型上下文限额、显示名称（i18n 感知）以及 `ModelConfig`、`UserStatusInfo` 等核心接口定义。v1.13.8 新增 `normalizeModelDisplayName()`（EN/ZH/双语显示名归一到当前语言唯一显示名）和 `resolveModelId()`（任意显示名 → 内部 modelId），为 Activity / GM / Quota 跨模块归一化提供统一锚点；后续又补了 `getQuotaPoolKey()`，显式固定已知模型的共享额度池，避免再靠 `resetTime` 猜池。
+模型上下文限额、显示名称（i18n 感知）以及 `ModelConfig`、`UserStatusInfo` 等核心接口定义。v1.13.8 新增 `normalizeModelDisplayName()`（EN/ZH/双语显示名归一到当前语言唯一显示名）和 `resolveModelId()`（任意显示名 → 内部 modelId），为 Activity / GM / Quota 跨模块归一化提供统一锚点；后续又补了 `getQuotaPoolKey()`，显式固定已知模型的共享额度池，避免再靠 `resetTime` 猜池。当前 `UserStatusInfo` 也包含计划来源、LS 原始计划字段与 cloud 校验字段，供状态栏与 Profile 页透明显示。
 
-Model context limits, display names (i18n-aware), and core interfaces. v1.13.8 adds `normalizeModelDisplayName()` (unifies EN/ZH/bilingual names to one canonical current-language name) and `resolveModelId()` (any display name → internal modelId), serving as the unified normalization anchor across Activity / GM / Quota modules; later `getQuotaPoolKey()` explicitly pins known shared-quota pools so the extension no longer guesses pools purely from `resetTime`.
+Model context limits, display names (i18n-aware), and core interfaces. v1.13.8 adds `normalizeModelDisplayName()` (unifies EN/ZH/bilingual names to one canonical current-language name) and `resolveModelId()` (any display name → internal modelId), serving as the unified normalization anchor across Activity / GM / Quota modules; later `getQuotaPoolKey()` explicitly pins known shared-quota pools so the extension no longer guesses pools purely from `resetTime`. `UserStatusInfo` now also carries plan-source metadata plus raw LS/cloud plan fields for transparent UI display.
 
 ---
 
@@ -151,7 +166,7 @@ Model context limits, display names (i18n-aware), and core interfaces. v1.13.8 a
 
 | 类 / Class | 说明 / Description |
 |---|---|
-| `StatusBarManager` | 状态栏项：上下文用量、颜色编码、额度指示、重置倒计时 |
+| `StatusBarManager` | 状态栏项：上下文用量、颜色编码、额度指示、重置倒计时、计划来源说明 |
 
 ---
 

--- a/src/cloud-plan.ts
+++ b/src/cloud-plan.ts
@@ -6,6 +6,7 @@ import { LSInfo } from './discovery';
 import { rpcCall } from './rpc-client';
 
 const CLOUD_PLAN_ENDPOINT = '/v1internal:loadCodeAssist';
+const CLOUD_USER_INFO_ENDPOINT = '/v1internal:fetchUserInfo';
 const CLOUD_PLAN_HOST = 'cloudcode-pa.googleapis.com';
 const CLOUD_PLAN_TIMEOUT_MS = 10_000;
 const CLOUD_PLAN_FRESH_CACHE_MS = 60_000;
@@ -33,6 +34,17 @@ export interface CloudPlanInfo {
     capturedAtIso: string;
     isStale: boolean;
     rawResponse?: Record<string, unknown>;
+    // ─── Environment fields ──────────────────────────────────────────────
+    /** User region from Cloud fetchUserInfo (e.g. "US") */
+    regionCode: string;
+    /** Whether user has a custom GCP Cloud AI Companion project */
+    hasCloudProject: boolean;
+    /** Antigravity IDE version from Unleash context */
+    ideVersion: string;
+    /** Unique installation ID from Unleash context */
+    installationId: string;
+    /** Whether user has Anthropic model access from Unleash context */
+    hasAnthropicModelAccess: boolean;
 }
 
 interface RegistryProcess {
@@ -62,18 +74,28 @@ export function mapCloudTierToDisplayPlan(
             planDetailName: tierName && tierName !== 'Free' ? tierName : '',
         };
     }
-    if (id.includes('standard')) {
+    if (id.includes('ultra')) {
         return {
-            displayPlanName: 'Standard',
-            displayTierKey: 'CLOUD_TIER_STANDARD',
-            planDetailName: tierName && tierName !== 'Standard' ? tierName : '',
+            displayPlanName: tierName || 'Ultra',
+            displayTierKey: 'CLOUD_TIER_ULTRA',
+            planDetailName: '',
         };
     }
     if (id.includes('pro')) {
         return {
-            displayPlanName: 'Pro',
+            displayPlanName: tierName || 'Pro',
             displayTierKey: 'CLOUD_TIER_PRO',
-            planDetailName: tierName && tierName !== 'Pro' ? tierName : '',
+            planDetailName: '',
+        };
+    }
+    // Google's "standard-tier" is the paid plan (e.g. "Gemini Code Assist"),
+    // not a mid-level tier. Use the cloud-provided tier name as display name
+    // to avoid misleading users into thinking they're on a lower plan.
+    if (id.includes('standard')) {
+        return {
+            displayPlanName: tierName || 'Standard',
+            displayTierKey: 'CLOUD_TIER_STANDARD',
+            planDetailName: '',
         };
     }
     return {
@@ -209,6 +231,7 @@ function cloudPostJson(
     bearerToken: string,
     body: Record<string, unknown>,
     signal?: AbortSignal,
+    pathname = CLOUD_PLAN_ENDPOINT,
 ): Promise<Record<string, unknown>> {
     return new Promise((resolve, reject) => {
         if (signal?.aborted) {
@@ -234,7 +257,7 @@ function cloudPostJson(
         const req = https.request({
             hostname: CLOUD_PLAN_HOST,
             port: 443,
-            path: CLOUD_PLAN_ENDPOINT,
+            path: pathname,
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${bearerToken}`,
@@ -329,6 +352,19 @@ export async function fetchCloudPlanInfo(ls: LSInfo, signal?: AbortSignal): Prom
         return cachedCloudPlan.value;
     }
 
+    // Extract unleash context properties for environment fields
+    let unleashIdeVersion = '';
+    let unleashInstallationId = '';
+    let unleashHasAnthropicAccess = false;
+    try {
+        const unleash = await getUnleashData(ls, signal);
+        const ctx = (unleash?.context || {}) as Record<string, unknown>;
+        const props = (ctx.properties || {}) as Record<string, unknown>;
+        unleashIdeVersion = (props.ideVersion as string) || '';
+        unleashInstallationId = (props.installationId as string) || '';
+        unleashHasAnthropicAccess = props.hasAnthropicModelAccess === 'true' || props.hasAnthropicModelAccess === true;
+    } catch { /* non-critical */ }
+
     try {
         const tokens = await discoverCloudTokens(ls, signal);
         if (tokens.length === 0) {
@@ -352,6 +388,13 @@ export async function fetchCloudPlanInfo(ls: LSInfo, signal?: AbortSignal): Prom
                 const { displayPlanName, displayTierKey, planDetailName } =
                     mapCloudTierToDisplayPlan(currentTierId, currentTierName);
 
+                // Fetch regionCode from Cloud fetchUserInfo (non-blocking)
+                let regionCode = '';
+                try {
+                    const userInfoResp = await cloudPostJson(token, {}, signal, CLOUD_USER_INFO_ENDPOINT);
+                    regionCode = (userInfoResp.regionCode as string) || '';
+                } catch { /* regionCode is best-effort */ }
+
                 const plan: CloudPlanInfo = {
                     currentTierId,
                     currentTierName,
@@ -366,6 +409,12 @@ export async function fetchCloudPlanInfo(ls: LSInfo, signal?: AbortSignal): Prom
                     capturedAtIso: new Date(now).toISOString(),
                     isStale: false,
                     rawResponse: resp,
+                    // Environment fields
+                    regionCode,
+                    hasCloudProject: !!currentTier.userDefinedCloudaicompanionProject,
+                    ideVersion: unleashIdeVersion,
+                    installationId: unleashInstallationId,
+                    hasAnthropicModelAccess: unleashHasAnthropicAccess,
                 };
                 cacheCloudPlan(plan, now, CLOUD_PLAN_FRESH_CACHE_MS, CLOUD_PLAN_STALE_REUSE_MS);
                 return plan;

--- a/src/cloud-plan.ts
+++ b/src/cloud-plan.ts
@@ -1,0 +1,394 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as http from 'http';
+import * as https from 'https';
+import { LSInfo } from './discovery';
+import { rpcCall } from './rpc-client';
+
+const CLOUD_PLAN_ENDPOINT = '/v1internal:loadCodeAssist';
+const CLOUD_PLAN_HOST = 'cloudcode-pa.googleapis.com';
+const CLOUD_PLAN_TIMEOUT_MS = 10_000;
+const CLOUD_PLAN_FRESH_CACHE_MS = 60_000;
+const CLOUD_PLAN_FAILURE_CACHE_MS = 15_000;
+const CLOUD_PLAN_STALE_REUSE_MS = 12 * 60 * 60 * 1000;
+
+export interface CloudAllowedTier {
+    id: string;
+    name: string;
+    description: string;
+    isDefault: boolean;
+}
+
+export interface CloudPlanInfo {
+    currentTierId: string;
+    currentTierName: string;
+    currentTierDescription: string;
+    displayPlanName: string;
+    displayTierKey: string;
+    planDetailName: string;
+    upgradeSubscriptionText: string;
+    upgradeSubscriptionUri: string;
+    upgradeSubscriptionType: string;
+    allowedTiers: CloudAllowedTier[];
+    capturedAtIso: string;
+    isStale: boolean;
+    rawResponse?: Record<string, unknown>;
+}
+
+interface RegistryProcess {
+    pid: number;
+    port: number;
+    csrfToken: string;
+    workspaceId?: string;
+}
+
+interface CachedCloudPlan {
+    expiresAt: number;
+    staleUntil: number;
+    value: CloudPlanInfo | null;
+}
+
+let cachedCloudPlan: CachedCloudPlan | null = null;
+
+export function mapCloudTierToDisplayPlan(
+    tierId: string,
+    tierName: string,
+): { displayPlanName: string; displayTierKey: string; planDetailName: string } {
+    const id = tierId.toLowerCase();
+    if (id.includes('free')) {
+        return {
+            displayPlanName: 'Free',
+            displayTierKey: 'CLOUD_TIER_FREE',
+            planDetailName: tierName && tierName !== 'Free' ? tierName : '',
+        };
+    }
+    if (id.includes('standard')) {
+        return {
+            displayPlanName: 'Standard',
+            displayTierKey: 'CLOUD_TIER_STANDARD',
+            planDetailName: tierName && tierName !== 'Standard' ? tierName : '',
+        };
+    }
+    if (id.includes('pro')) {
+        return {
+            displayPlanName: 'Pro',
+            displayTierKey: 'CLOUD_TIER_PRO',
+            planDetailName: tierName && tierName !== 'Pro' ? tierName : '',
+        };
+    }
+    return {
+        displayPlanName: tierName || '',
+        displayTierKey: tierName ? 'CLOUD_TIER_UNKNOWN' : '',
+        planDetailName: '',
+    };
+}
+
+function getRegistryProcesses(): RegistryProcess[] {
+    const regPath = path.join(
+        process.env.USERPROFILE || '',
+        '.gemini',
+        'antigravity',
+        'memory-store',
+        'ls-registry.json',
+    );
+    if (!fs.existsSync(regPath)) { return []; }
+    try {
+        const raw = JSON.parse(fs.readFileSync(regPath, 'utf8')) as { processes?: Record<string, RegistryProcess> };
+        return Object.values(raw.processes || {});
+    } catch {
+        return [];
+    }
+}
+
+async function getUnleashData(ls: LSInfo, signal?: AbortSignal): Promise<Record<string, unknown> | null> {
+    try {
+        return await rpcCall(ls, 'GetUnleashData', {
+            metadata: { ideName: 'antigravity', extensionName: 'antigravity' }
+        }, 8000, signal);
+    } catch {
+        return null;
+    }
+}
+
+function getUnleashDataFromRegistryProcess(proc: RegistryProcess, signal?: AbortSignal): Promise<Record<string, unknown> | null> {
+    return new Promise((resolve) => {
+        if (signal?.aborted) {
+            resolve(null);
+            return;
+        }
+
+        const postData = JSON.stringify({
+            metadata: { ideName: 'antigravity', extensionName: 'antigravity' }
+        });
+        const req = http.request({
+            hostname: '127.0.0.1',
+            port: proc.port,
+            path: '/exa.language_server_pb.LanguageServerService/GetUnleashData',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Connect-Protocol-Version': '1',
+                'x-codeium-csrf-token': proc.csrfToken,
+                'Content-Length': Buffer.byteLength(postData),
+            },
+            timeout: 8000,
+        }, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c: Buffer) => chunks.push(c));
+            res.on('end', () => {
+                if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
+                    resolve(null);
+                    return;
+                }
+                try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>); }
+                catch { resolve(null); }
+            });
+        });
+        req.on('error', () => resolve(null));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve(null);
+        });
+
+        let onAbort: (() => void) | undefined;
+        if (signal) {
+            onAbort = () => {
+                req.destroy();
+                resolve(null);
+            };
+            signal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        req.on('close', () => {
+            if (signal && onAbort) {
+                signal.removeEventListener('abort', onAbort);
+            }
+        });
+
+        req.write(postData);
+        req.end();
+    });
+}
+
+function extractCloudToken(unleash: Record<string, unknown> | null): string {
+    const context = (unleash?.context || {}) as Record<string, unknown>;
+    return (context.userId as string) || '';
+}
+
+function isSameProcess(proc: RegistryProcess, ls: LSInfo): boolean {
+    return proc.pid === ls.pid
+        && proc.port === ls.port
+        && proc.csrfToken === ls.csrfToken;
+}
+
+async function discoverCloudTokens(ls: LSInfo, signal?: AbortSignal): Promise<string[]> {
+    const tokens: string[] = [];
+    const seen = new Set<string>();
+    const pushToken = (token: string) => {
+        if (!token || seen.has(token)) { return; }
+        seen.add(token);
+        tokens.push(token);
+    };
+
+    // Prefer the LS already selected for this VS Code window.
+    pushToken(extractCloudToken(await getUnleashData(ls, signal)));
+
+    const registry = getRegistryProcesses().sort((a, b) => {
+        const aScore = (a.workspaceId ? 2 : 0) + (isSameProcess(a, ls) ? 1 : 0);
+        const bScore = (b.workspaceId ? 2 : 0) + (isSameProcess(b, ls) ? 1 : 0);
+        return bScore - aScore;
+    });
+    for (const proc of registry) {
+        if (isSameProcess(proc, ls)) { continue; }
+        pushToken(extractCloudToken(await getUnleashDataFromRegistryProcess(proc, signal)));
+    }
+    return tokens;
+}
+
+function cloudPostJson(
+    bearerToken: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new Error('Cloud plan request aborted'));
+            return;
+        }
+
+        let settled = false;
+        const safeResolve = (value: Record<string, unknown>) => {
+            if (settled) { return; }
+            settled = true;
+            cleanup();
+            resolve(value);
+        };
+        const safeReject = (err: Error) => {
+            if (settled) { return; }
+            settled = true;
+            cleanup();
+            reject(err);
+        };
+
+        const postData = JSON.stringify(body);
+        const req = https.request({
+            hostname: CLOUD_PLAN_HOST,
+            port: 443,
+            path: CLOUD_PLAN_ENDPOINT,
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${bearerToken}`,
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(postData),
+            },
+            timeout: CLOUD_PLAN_TIMEOUT_MS,
+        }, (res) => {
+            let data = '';
+            res.on('data', (chunk: Buffer | string) => { data += chunk; });
+            res.on('end', () => {
+                if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
+                    safeReject(new Error(`Cloud plan HTTP ${res.statusCode}: ${data.substring(0, 200)}`));
+                    return;
+                }
+                try {
+                    safeResolve(JSON.parse(data) as Record<string, unknown>);
+                } catch {
+                    safeReject(new Error(`Failed to parse cloud plan response: ${data.substring(0, 200)}`));
+                }
+            });
+        });
+
+        let onAbort: (() => void) | undefined;
+        const cleanup = () => {
+            if (signal && onAbort) {
+                signal.removeEventListener('abort', onAbort);
+                onAbort = undefined;
+            }
+        };
+
+        req.on('error', (err) => { safeReject(err as Error); });
+        req.on('timeout', () => {
+            req.destroy();
+            safeReject(new Error('Cloud plan timeout'));
+        });
+
+        if (signal) {
+            onAbort = () => {
+                req.destroy();
+                safeReject(new Error('Cloud plan request aborted'));
+            };
+            signal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        req.write(postData);
+        req.end();
+    });
+}
+
+function parseAllowedTiers(raw: unknown): CloudAllowedTier[] {
+    if (!Array.isArray(raw)) { return []; }
+    return raw.map((item) => {
+        const tier = (item || {}) as Record<string, unknown>;
+        return {
+            id: (tier.id as string) || '',
+            name: (tier.name as string) || '',
+            description: (tier.description as string) || '',
+            isDefault: !!tier.isDefault,
+        };
+    }).filter(t => t.id || t.name);
+}
+
+function cacheCloudPlan(value: CloudPlanInfo | null, now: number, expiresInMs: number, staleReuseMs = expiresInMs): void {
+    cachedCloudPlan = {
+        value,
+        expiresAt: now + expiresInMs,
+        staleUntil: now + staleReuseMs,
+    };
+}
+
+function applyFailureCooldown(now: number): void {
+    if (!cachedCloudPlan) { return; }
+    cachedCloudPlan = {
+        ...cachedCloudPlan,
+        expiresAt: now + CLOUD_PLAN_FAILURE_CACHE_MS,
+    };
+}
+
+function getReusableCachedCloudPlan(now: number): CloudPlanInfo | null {
+    if (!cachedCloudPlan?.value) { return null; }
+    if (cachedCloudPlan.staleUntil <= now) { return null; }
+    return {
+        ...cachedCloudPlan.value,
+        isStale: true,
+    };
+}
+
+export async function fetchCloudPlanInfo(ls: LSInfo, signal?: AbortSignal): Promise<CloudPlanInfo | null> {
+    const now = Date.now();
+    if (cachedCloudPlan && cachedCloudPlan.expiresAt > now) {
+        return cachedCloudPlan.value;
+    }
+
+    try {
+        const tokens = await discoverCloudTokens(ls, signal);
+        if (tokens.length === 0) {
+            const stalePlan = getReusableCachedCloudPlan(now);
+            if (stalePlan) {
+                applyFailureCooldown(now);
+                return stalePlan;
+            }
+            cacheCloudPlan(null, now, CLOUD_PLAN_FAILURE_CACHE_MS);
+            return null;
+        }
+
+        let lastError: unknown = null;
+        for (const token of tokens) {
+            try {
+                const resp = await cloudPostJson(token, {}, signal);
+                const currentTier = (resp.currentTier || {}) as Record<string, unknown>;
+                const currentTierId = (currentTier.id as string) || '';
+                const currentTierName = (currentTier.name as string) || '';
+                const currentTierDescription = (currentTier.description as string) || '';
+                const { displayPlanName, displayTierKey, planDetailName } =
+                    mapCloudTierToDisplayPlan(currentTierId, currentTierName);
+
+                const plan: CloudPlanInfo = {
+                    currentTierId,
+                    currentTierName,
+                    currentTierDescription,
+                    displayPlanName,
+                    displayTierKey,
+                    planDetailName,
+                    upgradeSubscriptionText: (currentTier.upgradeSubscriptionText as string) || '',
+                    upgradeSubscriptionUri: (currentTier.upgradeSubscriptionUri as string) || '',
+                    upgradeSubscriptionType: (currentTier.upgradeSubscriptionType as string) || '',
+                    allowedTiers: parseAllowedTiers(resp.allowedTiers),
+                    capturedAtIso: new Date(now).toISOString(),
+                    isStale: false,
+                    rawResponse: resp,
+                };
+                cacheCloudPlan(plan, now, CLOUD_PLAN_FRESH_CACHE_MS, CLOUD_PLAN_STALE_REUSE_MS);
+                return plan;
+            } catch (err) {
+                lastError = err;
+            }
+        }
+
+        if (lastError) {
+            const stalePlan = getReusableCachedCloudPlan(now);
+            if (stalePlan) {
+                applyFailureCooldown(now);
+                return stalePlan;
+            }
+        }
+    } catch {
+        const stalePlan = getReusableCachedCloudPlan(now);
+        if (stalePlan) {
+            applyFailureCooldown(now);
+            return stalePlan;
+        }
+    }
+
+    cacheCloudPlan(null, now, CLOUD_PLAN_FAILURE_CACHE_MS);
+    return null;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import {
     getModelDisplayName,
     normalizeUri,
     fetchFullUserStatus,
+    stabilizeUserStatusInfo,
     updateModelDisplayNames,
     ContextUsage,
     TrajectorySummary,
@@ -241,6 +242,21 @@ function makePanelPayload(extra: Partial<PanelPayload> = {}): PanelPayload {
     };
 }
 
+function updateCachedUserStatus(userInfo: UserStatusInfo): void {
+    const stableUserInfo = stabilizeUserStatusInfo(cachedUserInfo, userInfo);
+    if (!stableUserInfo) { return; }
+    cachedUserInfo = stableUserInfo;
+    statusBar.setPlanName(
+        stableUserInfo.planName,
+        stableUserInfo.planDetailName,
+        stableUserInfo.planSource,
+    );
+    durableGlobalState.update('cachedUserInfo', stableUserInfo);
+    durableGlobalState.update('cachedPlanName', stableUserInfo.planName);
+    durableGlobalState.update('cachedTierName', stableUserInfo.planDetailName);
+    durableGlobalState.update('cachedPlanSource', stableUserInfo.planSource);
+}
+
 // ─── Activation ───────────────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -362,14 +378,19 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Restore cached user status from globalState for instant tooltip display
     const savedConfigs = durableGlobalState.get<import('./models').ModelConfig[]>('cachedModelConfigs', []);
+    const savedUserInfo = durableGlobalState.get<UserStatusInfo | null>('cachedUserInfo', null);
     const savedPlan = durableGlobalState.get<string>('cachedPlanName', '');
     const savedTier = durableGlobalState.get<string>('cachedTierName', '');
+    const savedPlanSource = durableGlobalState.get<UserStatusInfo['planSource'] | ''>('cachedPlanSource', '');
     if (savedConfigs && savedConfigs.length > 0) {
         cachedModelConfigs = savedConfigs;
         statusBar.setModelConfigs(savedConfigs);
     }
-    if (savedPlan) {
-        statusBar.setPlanName(savedPlan, savedTier);
+    if (savedUserInfo) {
+        cachedUserInfo = savedUserInfo;
+        statusBar.setPlanName(savedUserInfo.planName, savedUserInfo.planDetailName, savedUserInfo.planSource);
+    } else if (savedPlan) {
+        statusBar.setPlanName(savedPlan, savedTier, savedPlanSource || undefined);
     }
 
     if (lastGMSummary && cachedModelConfigs.length > 0) {
@@ -593,13 +614,12 @@ async function pollContextUsage(): Promise<void> {
                     log(`Updated model display names: ${fullStatus.configs.map(c => c.label).join(', ')}`);
                 }
                 if (fullStatus.userInfo) {
-                    cachedUserInfo = fullStatus.userInfo;
-                    statusBar.setPlanName(fullStatus.userInfo.planName, fullStatus.userInfo.userTierName);
+                    updateCachedUserStatus(fullStatus.userInfo);
                     // Persist for instant display on next activation
                     durableGlobalState.update('cachedModelConfigs', cachedModelConfigs);
-                    durableGlobalState.update('cachedPlanName', fullStatus.userInfo.planName);
-                    durableGlobalState.update('cachedTierName', fullStatus.userInfo.userTierName);
-                    log(`User: ${fullStatus.userInfo.name} (${fullStatus.userInfo.planName}) credits: prompt=${fullStatus.userInfo.availablePromptCredits} flow=${fullStatus.userInfo.availableFlowCredits}`);
+                    if (cachedUserInfo) {
+                        log(`User: ${cachedUserInfo.name} (${cachedUserInfo.planName}, source=${cachedUserInfo.planSource}) credits: prompt=${cachedUserInfo.availablePromptCredits} flow=${cachedUserInfo.availableFlowCredits}`);
+                    }
                 }
             } catch { /* Silent degradation */ }
         } else {
@@ -628,11 +648,8 @@ async function pollContextUsage(): Promise<void> {
                                 checkQuotaNotification(fullStatus.configs);
                             }
                             if (fullStatus.userInfo) {
-                                cachedUserInfo = fullStatus.userInfo;
-                                statusBar.setPlanName(fullStatus.userInfo.planName, fullStatus.userInfo.userTierName);
+                                updateCachedUserStatus(fullStatus.userInfo);
                                 durableGlobalState.update('cachedModelConfigs', cachedModelConfigs);
-                                durableGlobalState.update('cachedPlanName', fullStatus.userInfo.planName);
-                                durableGlobalState.update('cachedTierName', fullStatus.userInfo.userTierName);
                             }
                         } catch { /* Silent */ }
                     }
@@ -655,11 +672,8 @@ async function pollContextUsage(): Promise<void> {
                         checkQuotaNotification(fullStatus.configs);
                     }
                     if (fullStatus.userInfo) {
-                        cachedUserInfo = fullStatus.userInfo;
-                        statusBar.setPlanName(fullStatus.userInfo.planName, fullStatus.userInfo.userTierName);
+                        updateCachedUserStatus(fullStatus.userInfo);
                         durableGlobalState.update('cachedModelConfigs', cachedModelConfigs);
-                        durableGlobalState.update('cachedPlanName', fullStatus.userInfo.planName);
-                        durableGlobalState.update('cachedTierName', fullStatus.userInfo.userTierName);
                     }
                     log('Refreshed user status (periodic)');
                 } catch { /* Silent — keep cached data */ }

--- a/src/models.ts
+++ b/src/models.ts
@@ -229,6 +229,17 @@ export interface UserStatusInfo {
     upgradeSubscriptionText: string;
     /** LS recommended model sort order from clientModelSorts */
     modelSortOrder: string[];
+    // ─── Environment fields (from Unleash context + Cloud endpoints) ──────
+    /** Antigravity IDE version from GetUnleashData.context.properties.ideVersion */
+    ideVersion: string;
+    /** Unique installation ID from GetUnleashData.context.properties.installationId */
+    installationId: string;
+    /** User region code from Cloud fetchUserInfo (e.g. "US") */
+    regionCode: string;
+    /** Whether user has Anthropic model access from Unleash context */
+    hasAnthropicModelAccess: boolean;
+    /** Whether user has a custom GCP Cloud AI Companion project */
+    hasCloudProject: boolean;
     /** Raw LS GetUserStatus response — for diagnostic Raw Data panel */
     _rawResponse?: Record<string, unknown>;
     /** Raw cloud loadCodeAssist response — for diagnostic Raw Data panel */

--- a/src/models.ts
+++ b/src/models.ts
@@ -165,17 +165,44 @@ export interface CreditInfo {
     minimumCreditAmountForUsage: number;
 }
 
+export interface CloudAllowedTierInfo {
+    id: string;
+    name: string;
+    description: string;
+    isDefault: boolean;
+}
+
 export interface UserStatusInfo {
     name: string;
     email: string;
     planName: string;
     teamsTier: string;
+    /** Secondary plan label shown in UI (for example cloud tier long name). */
+    planDetailName: string;
+    /** Which backend is used for the displayed plan fields. */
+    planSource: 'ls' | 'cloud' | 'cloud-cache';
     monthlyPromptCredits: number;
     monthlyFlowCredits: number;
     availablePromptCredits: number;
     availableFlowCredits: number;
     userTierName: string;
     userTierId: string;
+    /** Raw LS plan label before any cloud override. */
+    lsPlanName: string;
+    /** Raw LS teams tier before any cloud override. */
+    lsTeamsTier: string;
+    /** Cloud tier id returned by loadCodeAssist (e.g. free-tier). */
+    cloudTierId: string;
+    /** Cloud tier name returned by loadCodeAssist. */
+    cloudTierName: string;
+    /** Cloud tier description returned by loadCodeAssist. */
+    cloudTierDescription: string;
+    /** Cloud upgrade CTA target. */
+    cloudUpgradeSubscriptionUri: string;
+    /** Cloud upgrade type (e.g. GOOGLE_ONE_HELIUM). */
+    cloudUpgradeSubscriptionType: string;
+    /** Raw allowed tiers from cloud loadCodeAssist. */
+    cloudAllowedTiers: CloudAllowedTierInfo[];
     defaultModelLabel: string;
     planLimits: PlanLimits;
     teamConfig: TeamConfig;
@@ -196,12 +223,81 @@ export interface UserStatusInfo {
     // ─── Deep-mined fields (discovered via diag-deep-mine-profile) ────────
     /** Tier description from userTier.description (e.g. "Google AI Ultra") */
     userTierDescription: string;
+    /** Human-readable description for the displayed plan (cloud preferred, LS fallback). */
+    planDescription: string;
     /** Subscription status text from userTier.upgradeSubscriptionText */
     upgradeSubscriptionText: string;
     /** LS recommended model sort order from clientModelSorts */
     modelSortOrder: string[];
     /** Raw LS GetUserStatus response — for diagnostic Raw Data panel */
     _rawResponse?: Record<string, unknown>;
+    /** Raw cloud loadCodeAssist response — for diagnostic Raw Data panel */
+    _rawCloudPlanResponse?: Record<string, unknown>;
+}
+
+function isSameAccount(prev: UserStatusInfo, next: UserStatusInfo): boolean {
+    if (prev.email && next.email) {
+        return prev.email === next.email;
+    }
+    if (prev.name && next.name) {
+        return prev.name === next.name;
+    }
+    return false;
+}
+
+/**
+ * Keep the last cloud-verified plan visible when a later poll degrades to LS fallback.
+ *
+ * Diagnostics show that GetUserStatus can keep reporting a compatibility label
+ * such as "Pro" even when the cloud truth was previously captured as "Free".
+ * When that happens, preserve the earlier cloud-backed display plan and keep the
+ * rest of the freshly-polled quota/feature data from LS.
+ */
+export function stabilizeUserStatusInfo(
+    previous: UserStatusInfo | null,
+    current: UserStatusInfo | null,
+): UserStatusInfo | null {
+    if (!current) { return previous; }
+    if (!previous) { return current; }
+    if (current.planSource !== 'ls' || previous.planSource === 'ls') {
+        return current;
+    }
+    if (!isSameAccount(previous, current)) {
+        return current;
+    }
+    const previousCloudBacked = !!(
+        previous.cloudTierId
+        || previous.cloudTierName
+        || previous.planSource === 'cloud'
+        || previous.planSource === 'cloud-cache'
+    );
+    if (!previousCloudBacked) {
+        return current;
+    }
+    const planChanged = previous.planName !== current.planName
+        || previous.planDetailName !== current.planDetailName
+        || previous.teamsTier !== current.teamsTier;
+    if (!planChanged) {
+        return current;
+    }
+    return {
+        ...current,
+        planName: previous.planName,
+        teamsTier: previous.teamsTier,
+        planDetailName: previous.planDetailName,
+        planSource: 'cloud-cache',
+        planDescription: previous.planDescription || current.planDescription,
+        upgradeSubscriptionText: previous.upgradeSubscriptionText || current.upgradeSubscriptionText,
+        cloudTierId: previous.cloudTierId,
+        cloudTierName: previous.cloudTierName,
+        cloudTierDescription: previous.cloudTierDescription,
+        cloudUpgradeSubscriptionUri: previous.cloudUpgradeSubscriptionUri,
+        cloudUpgradeSubscriptionType: previous.cloudUpgradeSubscriptionType,
+        cloudAllowedTiers: previous.cloudAllowedTiers.length > 0
+            ? previous.cloudAllowedTiers
+            : current.cloudAllowedTiers,
+        _rawCloudPlanResponse: previous._rawCloudPlanResponse,
+    };
 }
 
 export interface FullUserStatus {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -115,6 +115,7 @@ export class StatusBarManager {
     private cachedConfigs: ModelConfig[] = [];
     private cachedPlanName: string = '';
     private cachedTierName: string = '';
+    private cachedPlanSource: 'ls' | 'cloud' | 'cloud-cache' | '' = '';
     /** User-configurable compression warning threshold (tokens). */
     private warningThreshold: number = 150_000;
     /** Timer ID for reset countdown. */
@@ -199,9 +200,10 @@ export class StatusBarManager {
     /**
      * Cache plan name for tooltip display.
      */
-    setPlanName(planName: string, tierName?: string): void {
+    setPlanName(planName: string, tierName?: string, source?: 'ls' | 'cloud' | 'cloud-cache'): void {
         this.cachedPlanName = planName;
         this.cachedTierName = tierName || '';
+        this.cachedPlanSource = source || '';
     }
 
     showInitializing(): void {
@@ -374,6 +376,10 @@ export class StatusBarManager {
                 ? `**${escapeMarkdown(this.cachedPlanName)}** · **${escapeMarkdown(this.cachedTierName)}**`
                 : `**${escapeMarkdown(this.cachedPlanName)}**`;
             result.push(`👤 ${tBi('Plan', '计划')}: ${planStr}`);
+            const sourceLabel = this.getPlanSourceLabel();
+            if (sourceLabel) {
+                result.push(`🔎 ${tBi('Source', '来源')}: ${sourceLabel}`);
+            }
         }
 
         const quotaModels = this.cachedConfigs.filter(c => c.quotaInfo);
@@ -435,6 +441,19 @@ export class StatusBarManager {
         result.push(`🎯 ${tBi('Compression warning', '压缩警告')}: **${formatTokenCount(this.warningThreshold)}**`);
 
         return result;
+    }
+
+    private getPlanSourceLabel(): string {
+        switch (this.cachedPlanSource) {
+            case 'cloud':
+                return tBi('Cloud verified', '云端校验');
+            case 'cloud-cache':
+                return tBi('Cloud verified (cached)', '云端校验（缓存）');
+            case 'ls':
+                return tBi('LS fallback', 'LS 兼容层');
+            default:
+                return '';
+        }
     }
 
     /**

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -201,7 +201,7 @@ export class StatusBarManager {
      */
     setPlanName(planName: string, tierName?: string): void {
         this.cachedPlanName = planName;
-        if (tierName) { this.cachedTierName = tierName; }
+        this.cachedTierName = tierName || '';
     }
 
     showInitializing(): void {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,9 +1,11 @@
 import { LSInfo } from './discovery';
 import { rpcCall } from './rpc-client';
+import { fetchCloudPlanInfo } from './cloud-plan';
 import {
     getContextLimit,
     getModelDisplayName,
     updateModelDisplayNames,
+    stabilizeUserStatusInfo,
     ModelConfig,
     FullUserStatus,
     UserStatusInfo,
@@ -27,6 +29,7 @@ export {
     getContextLimit,
     getModelDisplayName,
     updateModelDisplayNames,
+    stabilizeUserStatusInfo,
     ModelConfig,
     FullUserStatus,
     UserStatusInfo,
@@ -614,17 +617,37 @@ export async function fetchFullUserStatus(ls: LSInfo, signal?: AbortSignal): Pro
             return 0;
         };
 
+        const lsPlanName = (planInfo?.planName as string) || '';
+        const lsTeamsTier = (planInfo?.teamsTier as string) || '';
+        const lsUserTierName = (userTier?.name as string) || '';
+        const cloudPlan = await fetchCloudPlanInfo(ls, signal);
+        const displayPlanName = cloudPlan?.displayPlanName || lsPlanName;
+        const displayTeamsTier = cloudPlan?.displayTierKey || lsTeamsTier;
+        const planDetailName = cloudPlan?.planDetailName || lsUserTierName;
+        const effectiveUpgradeText = cloudPlan?.upgradeSubscriptionText || upgradeText;
+        const effectivePlanDescription = cloudPlan?.currentTierDescription || tierDescription;
+
         const userInfo: UserStatusInfo | null = planInfo ? {
             name: (userStatus.name as string) || '',
             email: (userStatus.email as string) || '',
-            planName: (planInfo.planName as string) || '',
-            teamsTier: (planInfo.teamsTier as string) || '',
+            planName: displayPlanName,
+            teamsTier: displayTeamsTier,
+            planDetailName,
+            planSource: cloudPlan ? (cloudPlan.isStale ? 'cloud-cache' : 'cloud') : 'ls',
             monthlyPromptCredits: (planInfo.monthlyPromptCredits as number) || 0,
             monthlyFlowCredits: (planInfo.monthlyFlowCredits as number) || 0,
             availablePromptCredits: (planStatus?.availablePromptCredits as number) ?? 0,
             availableFlowCredits: (planStatus?.availableFlowCredits as number) ?? 0,
-            userTierName: (userTier?.name as string) || '',
+            userTierName: lsUserTierName,
             userTierId: (userTier?.id as string) || '',
+            lsPlanName,
+            lsTeamsTier,
+            cloudTierId: cloudPlan?.currentTierId || '',
+            cloudTierName: cloudPlan?.currentTierName || '',
+            cloudTierDescription: cloudPlan?.currentTierDescription || '',
+            cloudUpgradeSubscriptionUri: cloudPlan?.upgradeSubscriptionUri || '',
+            cloudUpgradeSubscriptionType: cloudPlan?.upgradeSubscriptionType || '',
+            cloudAllowedTiers: cloudPlan?.allowedTiers || [],
             defaultModelLabel: defaultModelCfg?.label || defaultModelId || '',
             planLimits: {
                 maxNumChatInputTokens: parseNum(planInfo.maxNumChatInputTokens),
@@ -659,13 +682,15 @@ export async function fetchFullUserStatus(ls: LSInfo, signal?: AbortSignal): Pro
             canCustomizeAppIcon: (planInfo.canCustomizeAppIcon as boolean) || false,
             // Deep-mined fields
             userTierDescription: tierDescription,
-            upgradeSubscriptionText: upgradeText,
+            planDescription: effectivePlanDescription,
+            upgradeSubscriptionText: effectiveUpgradeText,
             modelSortOrder,
         } : null;
 
         // Attach raw LS response for transparency panel
         if (userInfo) {
             userInfo._rawResponse = resp as Record<string, unknown>;
+            userInfo._rawCloudPlanResponse = cloudPlan?.rawResponse;
         }
 
         return { configs, userInfo, rawResponse: resp as Record<string, unknown> };

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -685,6 +685,12 @@ export async function fetchFullUserStatus(ls: LSInfo, signal?: AbortSignal): Pro
             planDescription: effectivePlanDescription,
             upgradeSubscriptionText: effectiveUpgradeText,
             modelSortOrder,
+            // Environment fields (from Unleash context + Cloud endpoints)
+            ideVersion: cloudPlan?.ideVersion || '',
+            installationId: cloudPlan?.installationId || '',
+            regionCode: cloudPlan?.regionCode || '',
+            hasAnthropicModelAccess: cloudPlan?.hasAnthropicModelAccess || false,
+            hasCloudProject: cloudPlan?.hasCloudProject || false,
         } : null;
 
         // Attach raw LS response for transparency panel

--- a/src/webview-profile-tab.ts
+++ b/src/webview-profile-tab.ts
@@ -67,8 +67,12 @@ function buildAccountSection(userInfo: UserStatusInfo): string {
         'TEAMS_TIER_TEAMS': { bg: 'rgba(96,165,250,0.15)', color: 'var(--color-info)' },
         'TEAMS_TIER_ENTERPRISE_SAAS': { bg: 'rgba(156,163,175,0.15)', color: '#9ca3af' },
         'TEAMS_TIER_PRO_ULTIMATE': { bg: 'rgba(250,204,21,0.15)', color: 'var(--color-warn)' },
+        'CLOUD_TIER_FREE': { bg: 'rgba(156,163,175,0.15)', color: '#9ca3af' },
+        'CLOUD_TIER_STANDARD': { bg: 'rgba(74,222,128,0.15)', color: 'var(--color-ok)' },
+        'CLOUD_TIER_PRO': { bg: 'rgba(74,222,128,0.15)', color: 'var(--color-ok)' },
+        'CLOUD_TIER_UNKNOWN': { bg: 'rgba(96,165,250,0.15)', color: 'var(--color-info)' },
     };
-    const tier = tierMap[userInfo.teamsTier] || tierMap['TEAMS_TIER_PRO'];
+    const tier = tierMap[userInfo.teamsTier] || tierMap['CLOUD_TIER_UNKNOWN'];
     const maskedEmail = userInfo.email.replace(/^(.{2}).*(@.*)$/, '$1****$2');
 
     const promptPct = userInfo.monthlyPromptCredits > 0
@@ -81,6 +85,21 @@ function buildAccountSection(userInfo: UserStatusInfo): string {
     // Subscription hint
     const subHint = userInfo.upgradeSubscriptionText
         ? `<div class="subscription-hint">${esc(userInfo.upgradeSubscriptionText)}</div>` : '';
+    const displaySecondaryLabel = userInfo.planDetailName || userInfo.userTierName;
+    const planSourceNote = userInfo.planSource === 'cloud'
+        ? `<p class="raw-desc">${esc(tBi(
+            `Cloud verified plan: ${userInfo.cloudTierName || userInfo.planName}. LS compatibility tier: ${userInfo.lsPlanName || '-'} / ${userInfo.lsTeamsTier || '-'}.`,
+            `云端校验计划：${userInfo.cloudTierName || userInfo.planName}。LS 兼容层级：${userInfo.lsPlanName || '-'} / ${userInfo.lsTeamsTier || '-'}。`,
+        ))}</p>`
+        : userInfo.planSource === 'cloud-cache'
+            ? `<p class="raw-desc">${esc(tBi(
+                `Showing the last cloud-verified plan: ${userInfo.cloudTierName || userInfo.planName}. Current poll fell back to LS compatibility tier ${userInfo.lsPlanName || '-'} / ${userInfo.lsTeamsTier || '-'}.`,
+                `当前展示的是上次云端校验成功的计划：${userInfo.cloudTierName || userInfo.planName}。本轮轮询已退回 LS 兼容层级 ${userInfo.lsPlanName || '-'} / ${userInfo.lsTeamsTier || '-'}。`,
+            ))}</p>`
+            : `<p class="raw-desc">${esc(tBi(
+                `Plan is currently coming from LS compatibility data: ${userInfo.lsPlanName || userInfo.planName} / ${userInfo.lsTeamsTier || userInfo.teamsTier}. Cloud verification is unavailable in this poll.`,
+                `当前计划来自 LS 兼容层数据：${userInfo.lsPlanName || userInfo.planName} / ${userInfo.lsTeamsTier || userInfo.teamsTier}。本轮未拿到云端校验结果。`,
+            ))}</p>`;
 
     // Google AI Credits inline
     const validCredits = userInfo.availableCredits.filter(c => c.creditAmount > 0);
@@ -99,7 +118,7 @@ function buildAccountSection(userInfo: UserStatusInfo): string {
                 ${ICON.user}
                 ${tBi('Account', '账户')}
                 <span class="tier-badge" style="background:${tier.bg};color:${tier.color}">${esc(userInfo.planName)}</span>
-                ${userInfo.userTierName ? `<span class="tier-badge tier-sub" style="background:rgba(255,255,255,0.06);color:var(--color-text-dim)">${esc(userInfo.userTierName)}</span>` : ''}
+                ${displaySecondaryLabel ? `<span class="tier-badge tier-sub" style="background:rgba(255,255,255,0.06);color:var(--color-text-dim)">${esc(displaySecondaryLabel)}</span>` : ''}
                 <button class="privacy-btn" id="privacyToggle" aria-label="${tBi('Toggle privacy mask', '切换隐私遮罩')}">${ICON.shield}</button>
             </h2>
             <div class="account-info">
@@ -110,6 +129,7 @@ function buildAccountSection(userInfo: UserStatusInfo): string {
                 'Privacy mask is ON by default. Click the shield button above to reveal sensitive data.',
                 '隐私遮罩默认开启。点击上方 🛡️ 按钮可显示/隐藏真实信息。',
             )}</p>
+            ${planSourceNote}
             ${subHint}
             <div class="credits-section">
                 <div class="credit-row">
@@ -185,8 +205,8 @@ export function buildDefaultModelCard(userInfo: UserStatusInfo | null): string {
         <section class="card">
             <h2>${ICON.bolt} ${tBi('Default Model', '默认模型')}</h2>
             <div class="default-model">${tBi('Current default', '当前默认')}: <strong>${esc(userInfo.defaultModelLabel)}</strong></div>
-            ${userInfo.userTierDescription
-                ? `<p class="raw-desc">${esc(userInfo.userTierDescription)}</p>`
+            ${userInfo.planDescription
+                ? `<p class="raw-desc">${esc(userInfo.planDescription)}</p>`
                 : ''}
         </section>`;
 }

--- a/src/webview-profile-tab.ts
+++ b/src/webview-profile-tab.ts
@@ -1,4 +1,4 @@
-// ─── Profile Tab Content Builder ─────────────────────────────────────────────
+﻿// ─── Profile Tab Content Builder ─────────────────────────────────────────────
 // Builds HTML for the "Profile" tab: Account info, plan limits,
 // and feature/team config. Model-specific content is rendered in Models tab.
 
@@ -42,6 +42,7 @@ export function buildProfileContent(
     return [
         buildAccountSection(userInfo),
         buildLimitsSection(userInfo),
+        buildEnvironmentSection(userInfo),
         buildFeatureAndTeamGrid(userInfo),
     ].join('');
 }
@@ -70,6 +71,7 @@ function buildAccountSection(userInfo: UserStatusInfo): string {
         'CLOUD_TIER_FREE': { bg: 'rgba(156,163,175,0.15)', color: '#9ca3af' },
         'CLOUD_TIER_STANDARD': { bg: 'rgba(74,222,128,0.15)', color: 'var(--color-ok)' },
         'CLOUD_TIER_PRO': { bg: 'rgba(74,222,128,0.15)', color: 'var(--color-ok)' },
+        'CLOUD_TIER_ULTRA': { bg: 'rgba(250,204,21,0.15)', color: 'var(--color-warn)' },
         'CLOUD_TIER_UNKNOWN': { bg: 'rgba(96,165,250,0.15)', color: 'var(--color-info)' },
     };
     const tier = tierMap[userInfo.teamsTier] || tierMap['CLOUD_TIER_UNKNOWN'];
@@ -279,4 +281,46 @@ function buildFeatureAndTeamGrid(userInfo: UserStatusInfo): string {
                 <div class="profile-chip-grid">${teamTags}</div>
             </section>
         </div>`;
+}
+
+function buildEnvironmentSection(userInfo: UserStatusInfo): string {
+    const envItems: [string, string][] = [];
+    if (userInfo.ideVersion) {
+        envItems.push([tBi('IDE Version', 'IDE 版本'), esc(userInfo.ideVersion)]);
+    }
+    if (userInfo.installationId) {
+        const short = userInfo.installationId.length > 12
+            ? userInfo.installationId.substring(0, 12) + '\u2026'
+            : userInfo.installationId;
+        envItems.push([tBi('Installation ID', '安装 ID'), `<span title="${esc(userInfo.installationId)}">${esc(short)}</span>`]);
+    }
+    if (userInfo.regionCode) {
+        envItems.push([tBi('Region', '地区'), esc(userInfo.regionCode)]);
+    }
+    envItems.push([
+        tBi('Anthropic Models', 'Anthropic 模型'),
+        userInfo.hasAnthropicModelAccess
+            ? `<span style="color:var(--color-ok)">\u2713</span>`
+            : `<span style="color:var(--color-text-dim)">\u2717</span>`,
+    ]);
+    envItems.push([
+        tBi('Cloud Project', '云端项目'),
+        userInfo.hasCloudProject
+            ? `<span style="color:var(--color-ok)">\u2713</span>`
+            : `<span style="color:var(--color-text-dim)">\u2717</span>`,
+    ]);
+
+    if (envItems.length === 0) { return ''; }
+
+    const grid = envItems.map(([k, v]) => `
+        <div class="profile-metric-card">
+            <span class="profile-metric-label">${k}</span>
+            <span class="profile-metric-value">${v}</span>
+        </div>`).join('');
+
+    return `
+        <section class="card">
+            <h2>${ICON.bolt} ${tBi('Environment', '环境')}</h2>
+            <div class="profile-metric-grid">${grid}</div>
+        </section>`;
 }

--- a/tests/statusbar.test.ts
+++ b/tests/statusbar.test.ts
@@ -133,4 +133,13 @@ describe('StatusBarManager plan cache', () => {
         expect(tooltip).toContain('**Pro**');
         expect(tooltip).not.toContain('Google AI Ultra');
     });
+
+    it('shows the plan source in the hover tooltip when available', () => {
+        const manager = new StatusBarManager();
+        manager.setPlanName('Free', 'Gemini Code Assist for individuals', 'cloud-cache');
+        manager.showIdle();
+
+        const tooltip = ((manager as any).statusBarItem.tooltip as { value: string }).value;
+        expect(tooltip).toContain('Cloud verified (cached)');
+    });
 });

--- a/tests/statusbar.test.ts
+++ b/tests/statusbar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTokenCount, formatContextLimit, calculateCompressionStats } from '../src/statusbar';
+import { formatTokenCount, formatContextLimit, calculateCompressionStats, StatusBarManager } from '../src/statusbar';
 import { ContextUsage, ModelUsageInfo } from '../src/tracker';
 
 // ─── formatTokenCount ─────────────────────────────────────────────────────────
@@ -119,5 +119,18 @@ describe('calculateCompressionStats', () => {
         expect(stats!.dropTokens).toBe(50_000);
         // previousInput = 80K + 50K = 130K → dropPercent = 50K/130K ≈ 38.5%
         expect(stats!.dropPercent).toBeCloseTo(38.46, 1);
+    });
+});
+
+describe('StatusBarManager plan cache', () => {
+    it('should clear stale tier name when the latest status omits it', () => {
+        const manager = new StatusBarManager();
+        manager.setPlanName('Pro', 'Google AI Ultra');
+        manager.setPlanName('Pro', '');
+        manager.showIdle();
+
+        const tooltip = ((manager as any).statusBarItem.tooltip as { value: string }).value;
+        expect(tooltip).toContain('**Pro**');
+        expect(tooltip).not.toContain('Google AI Ultra');
     });
 });

--- a/tests/tracker.test.ts
+++ b/tests/tracker.test.ts
@@ -72,11 +72,11 @@ describe('mapCloudTierToDisplayPlan', () => {
         });
     });
 
-    it('should map standard-tier to Standard display plan', () => {
+    it('should map standard-tier to display plan using cloud tier name', () => {
         expect(mapCloudTierToDisplayPlan('standard-tier', 'Gemini Code Assist')).toEqual({
-            displayPlanName: 'Standard',
+            displayPlanName: 'Gemini Code Assist',
             displayTierKey: 'CLOUD_TIER_STANDARD',
-            planDetailName: 'Gemini Code Assist',
+            planDetailName: '',
         });
     });
 
@@ -142,6 +142,11 @@ function makeUserStatus(overrides: Partial<UserStatusInfo>): UserStatusInfo {
         planDescription: '',
         upgradeSubscriptionText: '',
         modelSortOrder: [],
+        ideVersion: '',
+        installationId: '',
+        regionCode: '',
+        hasAnthropicModelAccess: false,
+        hasCloudProject: false,
         ...overrides,
     };
 }

--- a/tests/tracker.test.ts
+++ b/tests/tracker.test.ts
@@ -4,6 +4,8 @@ import {
     estimateTokensFromText,
     normalizeUri,
 } from '../src/tracker';
+import { mapCloudTierToDisplayPlan } from '../src/cloud-plan';
+import { stabilizeUserStatusInfo, type UserStatusInfo } from '../src/models';
 import { StepType } from '../src/constants';
 
 // ─── normalizeUri ────────────────────────────────────────────────────────────
@@ -58,6 +60,133 @@ describe('estimateTokensFromText', () => {
     it('should handle mixed ASCII and non-ASCII', () => {
         const text = 'Hello 你好'; // 6 ASCII + 2 non-ASCII → ceil(6/4 + 2/1.5) = ceil(1.5 + 1.33) = 3
         expect(estimateTokensFromText(text)).toBe(3);
+    });
+});
+
+describe('mapCloudTierToDisplayPlan', () => {
+    it('should map free-tier to Free display plan', () => {
+        expect(mapCloudTierToDisplayPlan('free-tier', 'Gemini Code Assist for individuals')).toEqual({
+            displayPlanName: 'Free',
+            displayTierKey: 'CLOUD_TIER_FREE',
+            planDetailName: 'Gemini Code Assist for individuals',
+        });
+    });
+
+    it('should map standard-tier to Standard display plan', () => {
+        expect(mapCloudTierToDisplayPlan('standard-tier', 'Gemini Code Assist')).toEqual({
+            displayPlanName: 'Standard',
+            displayTierKey: 'CLOUD_TIER_STANDARD',
+            planDetailName: 'Gemini Code Assist',
+        });
+    });
+
+    it('should preserve unknown cloud tiers as-is', () => {
+        expect(mapCloudTierToDisplayPlan('mystery-tier', 'Custom Tier')).toEqual({
+            displayPlanName: 'Custom Tier',
+            displayTierKey: 'CLOUD_TIER_UNKNOWN',
+            planDetailName: '',
+        });
+    });
+});
+
+function makeUserStatus(overrides: Partial<UserStatusInfo>): UserStatusInfo {
+    return {
+        name: 'Gemini',
+        email: 'geminimoon2005@gmail.com',
+        planName: 'Pro',
+        teamsTier: 'TEAMS_TIER_PRO',
+        planDetailName: '',
+        planSource: 'ls',
+        monthlyPromptCredits: 50_000,
+        monthlyFlowCredits: 150_000,
+        availablePromptCredits: 500,
+        availableFlowCredits: 100,
+        userTierName: '',
+        userTierId: '',
+        lsPlanName: 'Pro',
+        lsTeamsTier: 'TEAMS_TIER_PRO',
+        cloudTierId: '',
+        cloudTierName: '',
+        cloudTierDescription: '',
+        cloudUpgradeSubscriptionUri: '',
+        cloudUpgradeSubscriptionType: '',
+        cloudAllowedTiers: [],
+        defaultModelLabel: 'Gemini 3.1 Pro (High)',
+        planLimits: {
+            maxNumChatInputTokens: 16384,
+            maxNumPremiumChatMessages: -1,
+            maxCustomChatInstructionCharacters: 600,
+            maxNumPinnedContextItems: -1,
+            maxLocalIndexSize: -1,
+            monthlyFlexCreditPurchaseAmount: 25_000,
+        },
+        teamConfig: {
+            allowMcpServers: true,
+            allowAutoRunCommands: true,
+            allowBrowserExperimentalFeatures: true,
+        },
+        availableCredits: [],
+        canBuyMoreCredits: true,
+        browserEnabled: true,
+        cascadeWebSearchEnabled: true,
+        knowledgeBaseEnabled: true,
+        canGenerateCommitMessages: true,
+        cascadeCanAutoRunCommands: true,
+        canAllowCascadeInBackground: true,
+        hasAutocompleteFastMode: true,
+        allowStickyPremiumModels: true,
+        allowPremiumCommandModels: true,
+        hasTabToJump: true,
+        canCustomizeAppIcon: true,
+        userTierDescription: '',
+        planDescription: '',
+        upgradeSubscriptionText: '',
+        modelSortOrder: [],
+        ...overrides,
+    };
+}
+
+describe('stabilizeUserStatusInfo', () => {
+    it('keeps the last cloud-verified plan when a later poll falls back to LS', () => {
+        const previous = makeUserStatus({
+            planName: 'Free',
+            teamsTier: 'CLOUD_TIER_FREE',
+            planDetailName: 'Gemini Code Assist for individuals',
+            planSource: 'cloud',
+            cloudTierId: 'free-tier',
+            cloudTierName: 'Gemini Code Assist for individuals',
+            cloudTierDescription: 'Gemini-powered code suggestions and chat in multiple IDEs',
+            planDescription: 'Gemini-powered code suggestions and chat in multiple IDEs',
+        });
+        const current = makeUserStatus({
+            availablePromptCredits: 420,
+            availableFlowCredits: 90,
+        });
+
+        const stabilized = stabilizeUserStatusInfo(previous, current);
+        expect(stabilized?.planName).toBe('Free');
+        expect(stabilized?.planDetailName).toBe('Gemini Code Assist for individuals');
+        expect(stabilized?.planSource).toBe('cloud-cache');
+        expect(stabilized?.availablePromptCredits).toBe(420);
+        expect(stabilized?.cloudTierId).toBe('free-tier');
+    });
+
+    it('does not reuse a previous cloud plan for a different account', () => {
+        const previous = makeUserStatus({
+            planName: 'Free',
+            teamsTier: 'CLOUD_TIER_FREE',
+            planDetailName: 'Gemini Code Assist for individuals',
+            planSource: 'cloud',
+            cloudTierId: 'free-tier',
+            cloudTierName: 'Gemini Code Assist for individuals',
+        });
+        const current = makeUserStatus({
+            email: 'other@example.com',
+        });
+
+        const stabilized = stabilizeUserStatusInfo(previous, current);
+        expect(stabilized?.planName).toBe('Pro');
+        expect(stabilized?.planSource).toBe('ls');
     });
 });
 


### PR DESCRIPTION
- Profile 面板新增"环境"卡片，展示 5 个诊断字段：
  IDE 版本、安装 ID、地区代码、Anthropic 模型访问权限、云端项目状态
- 数据来源：LS GetUnleashData 上下文 + Cloud fetchUserInfo/loadCodeAssist
- 修复付费计划被误标为"Standard"：mapCloudTierToDisplayPlan 现使用
  云端返回的 tierName（如"Gemini Code Assist"）替代硬编码标签
- 新增 CLOUD_TIER_ULTRA 金色徽章样式
- 补齐测试默认值及层级名称断言

- 状态栏悬浮中的计划信息优先显示当前校验过的真实计划
  - 云端计划暂时不可用时保留最近一次成功结果，避免显示来回跳变
  - 为计划显示补充来源说明，区分已校验结果与回退状态
  - 更新 CHANGELOG 与项目结构文档
  
提醒：采用了cloud云端捕捉的数据来显示正确的当前计划：tree
如果介意只用LS数据捕捉，则请驳回此拉取合并请求