### PR TITLE
v1.16.6: 模型生态适配 + 账号面板积分显示 + 诊断 ID 开关

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # 变更日志 / Changelog
 
+## [1.16.6] - 2026-05-12
+
+### ✨ Improved / 改进
+
+- **Gemini M16/M84 model ecosystem adaptation / Gemini M16/M84 模型生态适配**: Adapted to Gemini platform-level model remapping where M16 replaced M37 as Gemini 3.1 Pro (High) and M84 replaced M47 as Gemini 3 Flash. Added static context limits (M16: 120K, M84: 160K) and quota pool mappings to `models.ts`. Added `gemini-pro-default` pricing entry to `pricing-store.ts` to fix cost calculation for M16's responseModel.
+  适配 Gemini 平台模型重映射：M16 取代 M37 成为 Gemini 3.1 Pro (High)，M84 取代 M47 成为 Gemini 3 Flash。在 `models.ts` 中添加静态上下文限额（M16: 120K，M84: 160K）和额度池映射。在 `pricing-store.ts` 中添加 `gemini-pro-default` 定价条目，修复 M16 的费用计算。
+
+- **responseModel reverse alias resolution / responseModel 反向别名解析**: Added `responseModelAliases` registry and `registerResponseModelAlias()` in `models.ts`. When GM data reveals that `gemini-pro-default` maps to `MODEL_PLACEHOLDER_M16`, the alias is automatically registered so `normalizeModelDisplayName('gemini-pro-default')` correctly resolves to "Gemini 3.1 Pro (High)" instead of displaying the raw engine name. `resolveModelId()` now checks this alias map as an additional lookup layer. `gm/parser.ts` calls `registerResponseModelAlias()` during GM entry parsing to auto-learn mappings.
+  在 `models.ts` 中新增 `responseModelAliases` 注册表和 `registerResponseModelAlias()` 函数。当 GM 数据揭示 `gemini-pro-default` 映射到 `MODEL_PLACEHOLDER_M16` 时，别名会自动注册，使 `normalizeModelDisplayName('gemini-pro-default')` 能正确解析为 "Gemini 3.1 Pro (High)"，而不是显示裸引擎名。`resolveModelId()` 现在会将此别名表作为额外查找层。`gm/parser.ts` 在解析 GM 条目时自动调用 `registerResponseModelAlias()` 学习映射关系。
+
+- **Diagnostic short ID suffix on model display names / 模型显示名追加诊断短标识**: `normalizeModelDisplayName()` now appends the model's internal short ID as a suffix, e.g. "Gemini 3.1 Pro (High) (M16)", "Claude Opus 4.6 (Thinking) (M26)". This makes platform-level model ID changes (such as M37->M16 remapping) immediately visible in the Cost tab, GM Data, Model cards, and Monitor dashboard, serving as an early-warning canary for model ecosystem shifts. `resolveModelId()` automatically strips the suffix for backward compatibility with persisted data.
+  `normalizeModelDisplayName()` 现在会在模型显示名后追加内部短标识后缀，如 "Gemini 3.1 Pro (High) (M16)"、"Claude Opus 4.6 (Thinking) (M26)"。这样平台级模型 ID 变更（如 M37->M16 重映射）能直接在成本、GM 数据、模型卡片和监控面板中暴露，作为模型生态变动的早期预警信号。`resolveModelId()` 会自动剥离后缀以兼容历史持久化数据。
+
+### 📊 Stats / 统计
+
+- **Files changed**: 3 (`src/models.ts`, `src/pricing-store.ts`, `src/gm/parser.ts`)
+- **TypeScript compile**: Zero errors
+
+---
+
+
 ## [1.16.5] - 2026-05-07
 
 ### 🐛 Fixed / 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,21 @@
 - **responseModel reverse alias resolution / responseModel 反向别名解析**: Added `responseModelAliases` registry and `registerResponseModelAlias()` in `models.ts`. When GM data reveals that `gemini-pro-default` maps to `MODEL_PLACEHOLDER_M16`, the alias is automatically registered so `normalizeModelDisplayName('gemini-pro-default')` correctly resolves to "Gemini 3.1 Pro (High)" instead of displaying the raw engine name. `resolveModelId()` now checks this alias map as an additional lookup layer. `gm/parser.ts` calls `registerResponseModelAlias()` during GM entry parsing to auto-learn mappings.
   在 `models.ts` 中新增 `responseModelAliases` 注册表和 `registerResponseModelAlias()` 函数。当 GM 数据揭示 `gemini-pro-default` 映射到 `MODEL_PLACEHOLDER_M16` 时，别名会自动注册，使 `normalizeModelDisplayName('gemini-pro-default')` 能正确解析为 "Gemini 3.1 Pro (High)"，而不是显示裸引擎名。`resolveModelId()` 现在会将此别名表作为额外查找层。`gm/parser.ts` 在解析 GM 条目时自动调用 `registerResponseModelAlias()` 学习映射关系。
 
-- **Diagnostic short ID suffix on model display names / 模型显示名追加诊断短标识**: `normalizeModelDisplayName()` now appends the model's internal short ID as a suffix, e.g. "Gemini 3.1 Pro (High) (M16)", "Claude Opus 4.6 (Thinking) (M26)". This makes platform-level model ID changes (such as M37->M16 remapping) immediately visible in the Cost tab, GM Data, Model cards, and Monitor dashboard, serving as an early-warning canary for model ecosystem shifts. `resolveModelId()` automatically strips the suffix for backward compatibility with persisted data.
-  `normalizeModelDisplayName()` 现在会在模型显示名后追加内部短标识后缀，如 "Gemini 3.1 Pro (High) (M16)"、"Claude Opus 4.6 (Thinking) (M26)"。这样平台级模型 ID 变更（如 M37->M16 重映射）能直接在成本、GM 数据、模型卡片和监控面板中暴露，作为模型生态变动的早期预警信号。`resolveModelId()` 会自动剥离后缀以兼容历史持久化数据。
+- **Diagnostic short ID suffix on model display names / 模型显示名追加诊断短标识**: `normalizeModelDisplayName()` now appends the model's internal short ID as a suffix, e.g. "Gemini 3.1 Pro (High) (M16)", "Claude Opus 4.6 (Thinking) (M26)". This makes platform-level model ID changes (such as M37->M16 remapping) immediately visible in the Cost tab, GM Data, Model cards, and Monitor dashboard, serving as an early-warning canary for model ecosystem shifts. `resolveModelId()` automatically strips the suffix for backward compatibility with persisted data. **Disabled by default** — controlled via the new `showModelInternalId` setting (see below).
+  `normalizeModelDisplayName()` 现在会在模型显示名后追加内部短标识后缀，如 "Gemini 3.1 Pro (High) (M16)"、"Claude Opus 4.6 (Thinking) (M26)"。平台级模型 ID 变更（如 M37->M16 重映射）能直接暴露在 UI 中作为早期预警。`resolveModelId()` 会自动剥离后缀以兼容历史数据。**默认关闭**——通过下方新增的 `showModelInternalId` 设置控制。
+
+- **Show Model Internal ID setting / 显示模型内部 ID 设置项**: Added `antigravityContextMonitor.showModelInternalId` setting (default: `false`) with a toggle in the Settings tab under "Advanced Display". When enabled, all model display names append their internal short ID (e.g. `(M16)`, `(M26)`) and the status bar tooltip shows the shadow/checkpoint model identifier. Changes take effect immediately without reload.
+  新增 `antigravityContextMonitor.showModelInternalId` 设置项（默认 `false`），在设置标签页「高级显示」区域提供开关。开启后所有模型名追加内部短标识（如 `(M16)`、`(M26)`），状态栏 tooltip 也会显示影子/检查点模型标识。修改即时生效，无需重新加载。
+
+- **Cost aggregation merges same-model rows / 成本汇总合并同模型行**: `calculateCosts()` in `pricing-store.ts` and `buildMonthlyCostSummary()` in `pricing-panel.ts` now merge cost rows by base model name (via new `getModelBaseName()`). Models sharing the same display name but different internal IDs (e.g. M37 and M16 both being "Gemini 3.1 Pro (High)") are combined into a single cost row with summed totals, instead of appearing as separate entries.
+  `pricing-store.ts` 的 `calculateCosts()` 和 `pricing-panel.ts` 的 `buildMonthlyCostSummary()` 现在按 base 模型名（通过新增的 `getModelBaseName()`）合并费用行。同一模型不同内部 ID（如 M37 和 M16 都是 "Gemini 3.1 Pro (High)"）会合并为一行统一显示总额，不再分开显示。
+
+- **Legacy model name fallback / 退役模型名兜底**: Added `LEGACY_MODEL_NAMES` static map in `models.ts` for retired model IDs (M37 -> "Gemini 3.1 Pro (High)", M47 -> "Gemini 3 Flash"). Historical calendar and cost data that references these retired IDs now displays proper model names instead of raw placeholder strings.
+  在 `models.ts` 中新增 `LEGACY_MODEL_NAMES` 静态映射表，为已退役模型 ID（M37 -> "Gemini 3.1 Pro (High)"，M47 -> "Gemini 3 Flash"）提供兜底显示名。引用这些退役 ID 的历史日历和成本数据现在能正确显示模型名而非裸占位符。
 
 ### 📊 Stats / 统计
 
-- **Files changed**: 3 (`src/models.ts`, `src/pricing-store.ts`, `src/gm/parser.ts`)
+- **Files changed**: 7 (`src/models.ts`, `src/tracker.ts`, `src/extension.ts`, `src/pricing-store.ts`, `src/pricing-panel.ts`, `src/webview-settings-tab.ts`, `src/webview-script.ts`, `src/statusbar.ts`, `package.json`)
 - **TypeScript compile**: Zero errors
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,15 @@
 - **Legacy model name fallback / 退役模型名兜底**: Added `LEGACY_MODEL_NAMES` static map in `models.ts` for retired model IDs (M37 -> "Gemini 3.1 Pro (High)", M47 -> "Gemini 3 Flash"). Historical calendar and cost data that references these retired IDs now displays proper model names instead of raw placeholder strings.
   在 `models.ts` 中新增 `LEGACY_MODEL_NAMES` 静态映射表，为已退役模型 ID（M37 -> "Gemini 3.1 Pro (High)"，M47 -> "Gemini 3 Flash"）提供兜底显示名。引用这些退役 ID 的历史日历和成本数据现在能正确显示模型名而非裸占位符。
 
+- **Account panel shows credits per account / 账号面板显示积分**: `AccountSnapshot` now stores `credits` (from `availableCredits`). Each account card in the popover displays credit chips (e.g. "GOOGLE ONE AI **18,350**") below the email line, making it easy to compare balances across multi-account setups.
+  `AccountSnapshot` 现在存储 `credits`（来自 `availableCredits`）。弹窗中每个账号卡片在邮箱下方显示积分标签（如 "GOOGLE ONE AI **18,350**"），方便多账号场景下对比余额。
+
+- **Account card layout overhaul / 账号卡片布局重排**: Identity section now shows 4 distinct rows: name + status, email, plan badge, and credits. Quota pool rows moved progress bar to far-right for consistent alignment. Removed popover-specific `flex-wrap: wrap` override that forced pools onto a separate line, eliminating the empty space at top-right.
+  身份区域拆为四行：名字+状态、邮箱、会员计划、积分。配额池行将进度条移至最右侧对齐。移除 popover 的 `flex-wrap: wrap` 覆盖，池子不再独占一行，消除右上角空白。
+
 ### 📊 Stats / 统计
 
-- **Files changed**: 7 (`src/models.ts`, `src/tracker.ts`, `src/extension.ts`, `src/pricing-store.ts`, `src/pricing-panel.ts`, `src/webview-settings-tab.ts`, `src/webview-script.ts`, `src/statusbar.ts`, `package.json`)
+- **Files changed**: 10 (`src/models.ts`, `src/tracker.ts`, `src/extension.ts`, `src/pricing-store.ts`, `src/pricing-panel.ts`, `src/webview-settings-tab.ts`, `src/webview-script.ts`, `src/statusbar.ts`, `src/activity-panel.ts`, `src/webview-styles.ts`, `src/webview-panel.ts`, `package.json`)
 - **TypeScript compile**: Zero errors
 
 ---

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "minimum": 1,
           "maximum": 100,
           "description": "Maximum number of activity archives to keep / 活动归档最多保留份数"
+        },
+        "antigravityContextMonitor.showModelInternalId": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show internal model ID suffix (e.g. M16, M26) next to model display names. Useful for diagnosing platform-level model changes. / 在模型名后显示内部 ID 后缀（如 M16、M26），用于诊断平台级模型变更。"
         }
       }
     }

--- a/src/activity-panel.ts
+++ b/src/activity-panel.ts
@@ -46,6 +46,8 @@ export interface AccountSnapshot {
     isActive: boolean;
     /** Last time this snapshot was updated (ISO timestamp) */
     lastSeen: string;
+    /** Available credit balances (e.g. Google One AI credits) */
+    credits?: { creditType: string; creditAmount: number }[];
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -149,9 +151,9 @@ export function getGMDataTabStyles(): string {
     }
     .acct-card {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: var(--space-2);
-        padding: 6px var(--space-3);
+        padding: 8px var(--space-3);
         border-bottom: 1px solid var(--color-border-subtle);
         font-size: 0.85em;
         transition: background 0.15s cubic-bezier(.4,0,.2,1);
@@ -165,6 +167,7 @@ export function getGMDataTabStyles(): string {
         height: 8px;
         border-radius: 50%;
         flex-shrink: 0;
+        margin-top: 5px;
     }
     .acct-indicator-active {
         background: var(--color-ok);
@@ -201,13 +204,15 @@ export function getGMDataTabStyles(): string {
         white-space: nowrap;
     }
     .acct-plan {
-        flex-shrink: 0;
+        display: inline-block;
         padding: 1px 6px;
         border-radius: var(--radius-sm);
-        font-size: 0.75em;
+        font-size: 0.72em;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.5px;
+        align-self: flex-start;
+        width: fit-content;
     }
     .acct-plan-pro {
         background: var(--color-info-border-dim);
@@ -358,6 +363,35 @@ export function getGMDataTabStyles(): string {
     .acct-delete-link:hover {
         opacity: 1;
         text-decoration: underline;
+    }
+    .acct-credits {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 3px;
+        margin-top: 1px;
+    }
+    .acct-credit-chip {
+        display: inline-block;
+        padding: 0 5px;
+        border-radius: var(--radius-sm);
+        font-size: 0.68em;
+        line-height: 1.6;
+        white-space: nowrap;
+        background: rgba(250,204,21,0.08);
+        color: var(--color-text-dim);
+        border: 1px solid rgba(250,204,21,0.2);
+        letter-spacing: 0.3px;
+    }
+    .acct-credit-chip b {
+        color: var(--color-amber);
+        font-weight: 600;
+    }
+    body.vscode-light .acct-credit-chip {
+        background: rgba(202,138,4,0.06);
+        border-color: rgba(202,138,4,0.15);
+    }
+    body.vscode-light .acct-credit-chip b {
+        color: #b45309;
     }
 
     /* ─── Pending Archive Panel ─── */
@@ -3603,9 +3637,9 @@ export function buildAccountStatusPanel(snapshots: AccountSnapshot[]): string {
                 const countdown = formatResetCountdown(pool.resetTime, nowMs);
                 const warnClass = diffMs < 30 * 60 * 1000 ? ' acct-reset-countdown-warn' : '';
                 return `<div class="acct-pool-row">
-                    ${buildQuotaBar(pool.remainingPercent)}
                     <div class="acct-pool-models">${modelChips}${extraChip}</div>
                     <span class="acct-reset-countdown${warnClass}">${countdown}</span>
+                    ${buildQuotaBar(pool.remainingPercent)}
                 </div>`;
             }).filter(Boolean).join('');
 
@@ -3627,13 +3661,25 @@ export function buildAccountStatusPanel(snapshots: AccountSnapshot[]): string {
             ? `<button class="acct-delete-link acct-delete-btn" data-email="${esc(snap.email)}" title="${tBi('Remove cached account', '移除缓存账号')}">${tBi('Remove', '移除')}</button>`
             : '';
 
+        // Build credits chips (e.g. "GOOGLE AI 18,590")
+        const creditsChips = (snap.credits && snap.credits.length > 0)
+            ? snap.credits.map(c => {
+                const label = c.creditType.replace('CREDIT_TYPE_', '').replace(/_/g, ' ');
+                return `<span class="acct-credit-chip">${esc(label)} <b>${c.creditAmount.toLocaleString()}</b></span>`;
+            }).join('')
+            : '';
+        const creditsRow = creditsChips
+            ? `<div class="acct-credits">${creditsChips}</div>`
+            : '';
+
         return `<div class="acct-card">
             <div class="acct-indicator ${indicatorClass}"></div>
             <div class="acct-identity">
                 <span class="acct-name">${esc(snap.name || '—')} ${statusTag}${deleteLink ? ` ${deleteLink}` : ''}</span>
                 <span class="acct-email">${esc(snap.email)}</span>
+                <span class="acct-plan ${planClass}">${esc(planLabel)}</span>
+                ${creditsRow}
             </div>
-            <span class="acct-plan ${planClass}">${esc(planLabel)}</span>
             ${resetHtml}
         </div>`;
     }).join('');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
     getContextUsage,
     getContextLimit,
     getModelDisplayName,
+    normalizeModelDisplayName,
     normalizeUri,
     fetchFullUserStatus,
     updateModelDisplayNames,
@@ -13,6 +14,7 @@ import {
     TrajectorySummary,
     UserStatusInfo,
 } from './tracker';
+import { setShowModelShortId } from './models';
 import { StatusBarManager, formatContextLimit } from './statusbar';
 import { initI18n, initI18nFromState, showLanguagePicker, tBi } from './i18n';
 import { showMonitorPanel, updateMonitorPanel, isMonitorPanelVisible, setPanelDurableState, PanelPayload, LARGE_STATE_FILE_WARN_BYTES } from './webview-panel';
@@ -172,7 +174,7 @@ function rehydrateUsageForDisplay(
     customLimits?: Record<string, number>,
 ): ContextUsage {
     const model = usage.model || usage.lastModelUsage?.model || '';
-    const modelDisplayName = getModelDisplayName(model);
+    const modelDisplayName = normalizeModelDisplayName(model);
     const contextLimit = getContextLimit(model, customLimits);
     const usagePercent = contextLimit > 0 ? (usage.contextUsed / contextLimit) * 100 : 0;
     if (
@@ -857,6 +859,9 @@ export function activate(context: vscode.ExtensionContext): void {
     // Apply status bar display preferences
     applyDisplayPrefs();
 
+    // Apply model internal ID display setting
+    setShowModelShortId(config.get<boolean>('showModelInternalId', false));
+
     schedulePoll();
 
     // Ensure timer and abort controller are cleaned up when extension is disposed
@@ -894,6 +899,11 @@ export function activate(context: vscode.ExtensionContext): void {
             if (e.affectsConfiguration('antigravityContextMonitor.statusBar')) {
                 applyDisplayPrefs();
                 log('Status bar display preferences updated');
+            }
+            if (e.affectsConfiguration('antigravityContextMonitor.showModelInternalId')) {
+                const newConfig = vscode.workspace.getConfiguration('antigravityContextMonitor');
+                setShowModelShortId(newConfig.get<boolean>('showModelInternalId', false));
+                log('Model internal ID display setting updated');
             }
         }),
         // ─── Workspace Switch Detection ─────────────────────────────────────

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -446,6 +446,10 @@ function updateAccountSnapshot(
     }
 
     // Upsert current account
+    const validCredits = (userInfo.availableCredits || [])
+        .filter(c => c.creditAmount > 0)
+        .map(c => ({ creditType: c.creditType, creditAmount: c.creditAmount }));
+
     accountSnapshots.set(email, {
         email,
         name: userInfo.name || '',
@@ -456,6 +460,7 @@ function updateAccountSnapshot(
         resetPools,
         isActive: true,
         lastSeen: new Date().toISOString(),
+        credits: validCredits.length > 0 ? validCredits : undefined,
     });
 
     // Persist to durable state

--- a/src/gm/parser.ts
+++ b/src/gm/parser.ts
@@ -1,7 +1,7 @@
 // ─── GM Parser ───────────────────────────────────────────────────────────────
 // Parsing helpers, prompt extraction, and entry builder for GM data.
 
-import { normalizeModelDisplayName } from '../models';
+import { normalizeModelDisplayName, registerResponseModelAlias } from '../models';
 import type {
     GMCallEntry,
     GMCheckpointSummary,
@@ -653,6 +653,12 @@ export function parseGMEntry(gm: Record<string, unknown>): GMCallEntry {
     const modelId = (cm.model as string) || '';
     const responseModel = (cm.responseModel as string) || '';
     const modelAccuracy: GMModelAccuracy = responseModel ? 'exact' : 'placeholder';
+
+    // Register responseModel -> placeholder alias for display name resolution
+    // e.g. 'gemini-pro-default' -> 'MODEL_PLACEHOLDER_M16' -> "Gemini 3.1 Pro (High)"
+    if (responseModel && modelId) {
+        registerResponseModelAlias(responseModel, modelId);
+    }
 
     // Model DNA fields
     const completionConfig = parseCompletionConfig(cm.completionConfig as Record<string, unknown>);

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,11 +14,13 @@ export const DEFAULT_CONTEXT_LIMITS: Record<string, number> = {
     // ── Platform truncation thresholds (from GM plannerConfig.truncationThresholdTokens) ──
     // These are the ACTUAL context window limits enforced by the platform,
     // NOT the model's native context window size.
-    // Verified via diag-scripts/overview/model-compare.ts (2026-04-24).
-    'MODEL_PLACEHOLDER_M37': 120_000,   // Gemini 3.1 Pro (High) — platform says 160K but compression triggers at ~125K
+    // Verified via diag-scripts/overview/model-compare.ts (2026-05-12).
+    'MODEL_PLACEHOLDER_M16': 120_000,   // Gemini 3.1 Pro (High) — new ID (gemini-pro-default), compression triggers ~120K
+    'MODEL_PLACEHOLDER_M37': 120_000,   // [Legacy] Gemini 3.1 Pro (High) — now demoted to planModel/dispatcher
     'MODEL_PLACEHOLDER_M36': 120_000,   // Gemini 3.1 Pro (Low)  — same pool as High
-    'MODEL_PLACEHOLDER_M47': 160_000,   // Gemini 3 Flash
-    'MODEL_PLACEHOLDER_M18': 160_000,   // [Legacy] Gemini 3 Flash (old ID)
+    'MODEL_PLACEHOLDER_M84': 160_000,   // Gemini 3 Flash — new ID
+    'MODEL_PLACEHOLDER_M47': 160_000,   // [Legacy] Gemini 3 Flash (old ID)
+    'MODEL_PLACEHOLDER_M18': 160_000,   // [Legacy] Gemini 3 Flash (older ID)
     'MODEL_PLACEHOLDER_M35': 160_000,   // Claude Sonnet 4.6 (Thinking) — truncationThresholdTokens=160000
     'MODEL_PLACEHOLDER_M26': 160_000,   // Claude Opus 4.6 (Thinking)  — truncationThresholdTokens=160000
     'MODEL_OPENAI_GPT_OSS_120B_MEDIUM': 128_000,  // GPT-OSS 120B (Medium)
@@ -31,10 +33,14 @@ export const DEFAULT_CONTEXT_LIMIT = 160_000;
 // the LS GetUserStatus API. No hardcoded model names.
 
 let modelDisplayNames: Record<string, string> = {};
+/** responseModel -> placeholder ID reverse map (populated from GM data). */
+let responseModelAliases: Record<string, string> = {};
 
 const KNOWN_QUOTA_POOLS: Record<string, string> = {
+    'MODEL_PLACEHOLDER_M16': 'gemini-pro',
     'MODEL_PLACEHOLDER_M37': 'gemini-pro',
     'MODEL_PLACEHOLDER_M36': 'gemini-pro',
+    'MODEL_PLACEHOLDER_M84': 'gemini-flash',
     'MODEL_PLACEHOLDER_M47': 'gemini-flash',
     'MODEL_PLACEHOLDER_M18': 'gemini-flash',
     'MODEL_PLACEHOLDER_M35': 'claude-premium',
@@ -80,6 +86,17 @@ export function getModelDisplayName(model: string): string {
 }
 
 /**
+ * Extract a short diagnostic ID from a model placeholder.
+ * e.g. MODEL_PLACEHOLDER_M16 → "M16", MODEL_OPENAI_GPT_OSS_120B_MEDIUM → "OSS-120B"
+ */
+export function getModelShortId(modelId: string): string {
+    const m = modelId.match(/MODEL_PLACEHOLDER_(M\d+)/);
+    if (m) { return m[1]; }
+    if (modelId === 'MODEL_OPENAI_GPT_OSS_120B_MEDIUM') { return 'OSS-120B'; }
+    return '';
+}
+
+/**
  * Resolve a model ID or display label back to the canonical model ID.
  */
 export function resolveModelId(modelOrDisplay: string): string | undefined {
@@ -93,9 +110,18 @@ export function resolveModelId(modelOrDisplay: string): string | undefined {
             return modelId;
         }
     }
+    // responseModel alias lookup (e.g. "gemini-pro-default" → "MODEL_PLACEHOLDER_M16")
+    const fromResponseModel = responseModelAliases[clean];
+    if (fromResponseModel) { return fromResponseModel; }
     // Legacy Chinese name fallback (pre-v1.16 persisted data migration)
     const legacyId = LEGACY_ZH_MODEL_NAMES[clean];
     if (legacyId) { return legacyId; }
+    // Strip trailing diagnostic suffix "(Mxx)" and retry — handles persisted keys
+    // that include the short ID appended by normalizeModelDisplayName()
+    const suffixStripped = clean.replace(/\s*\(M\d+\)$/, '').replace(/\s*\(OSS-120B\)$/, '');
+    if (suffixStripped !== clean && suffixStripped) {
+        return resolveModelId(suffixStripped);
+    }
     return undefined;
 }
 
@@ -107,7 +133,15 @@ export function normalizeModelDisplayName(modelOrDisplay: string): string {
     const clean = modelOrDisplay.trim();
     if (!clean) { return ''; }
     const modelId = resolveModelId(clean);
-    return modelId ? getModelDisplayName(modelId) : clean;
+    if (!modelId) { return clean; }
+    const displayName = getModelDisplayName(modelId);
+    const shortId = getModelShortId(modelId);
+    // Append diagnostic short ID when display name is resolved (not raw placeholder)
+    // e.g. "Gemini 3.1 Pro (High)" + "M16" → "Gemini 3.1 Pro (High) (M16)"
+    if (shortId && displayName !== modelId && !displayName.includes(`(${shortId})`)) {
+        return `${displayName} (${shortId})`;
+    }
+    return displayName;
 }
 
 /**
@@ -217,5 +251,17 @@ export function updateModelDisplayNames(configs: ModelConfig[]): void {
         if (c.model && c.label) {
             modelDisplayNames[c.model] = c.label;
         }
+    }
+}
+
+/**
+ * Register a responseModel → placeholder ID alias.
+ * Called from GM data processing when we discover the mapping.
+ * e.g. registerResponseModelAlias('gemini-pro-default', 'MODEL_PLACEHOLDER_M16')
+ * Allows resolveModelId('gemini-pro-default') → 'MODEL_PLACEHOLDER_M16' → "Gemini 3.1 Pro (High)"
+ */
+export function registerResponseModelAlias(responseModel: string, placeholderId: string): void {
+    if (responseModel && placeholderId && responseModel !== placeholderId) {
+        responseModelAliases[responseModel] = placeholderId;
     }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -35,6 +35,8 @@ export const DEFAULT_CONTEXT_LIMIT = 160_000;
 let modelDisplayNames: Record<string, string> = {};
 /** responseModel -> placeholder ID reverse map (populated from GM data). */
 let responseModelAliases: Record<string, string> = {};
+/** Whether to append diagnostic short ID suffix (e.g. "(M16)") to display names. */
+let showModelShortId = false;
 
 const KNOWN_QUOTA_POOLS: Record<string, string> = {
     'MODEL_PLACEHOLDER_M16': 'gemini-pro',
@@ -61,6 +63,16 @@ const LEGACY_ZH_MODEL_NAMES: Record<string, string> = {
     'GPT-OSS 120B (中)': 'MODEL_OPENAI_GPT_OSS_120B_MEDIUM',
 };
 
+// ─── Retired Model Display Names ─────────────────────────────────────────────
+// Models that have been retired from clientModelConfigs (e.g. replaced by newer
+// placeholder IDs) but may still appear in persisted/archived daily data.
+// Provides getModelDisplayName() fallback so they don't render as raw IDs.
+
+const LEGACY_MODEL_NAMES: Record<string, string> = {
+    'MODEL_PLACEHOLDER_M37': 'Gemini 3.1 Pro (High)',  // Replaced by M16
+    'MODEL_PLACEHOLDER_M47': 'Gemini 3 Flash',         // Replaced by M84
+};
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
@@ -82,7 +94,7 @@ export function getContextLimit(
  * Returns the API-provided label, or the raw model ID if not yet loaded.
  */
 export function getModelDisplayName(model: string): string {
-    return modelDisplayNames[model] || model || 'Unknown Model';
+    return modelDisplayNames[model] || LEGACY_MODEL_NAMES[model] || model || 'Unknown Model';
 }
 
 /**
@@ -102,8 +114,8 @@ export function getModelShortId(modelId: string): string {
 export function resolveModelId(modelOrDisplay: string): string | undefined {
     const clean = modelOrDisplay.trim();
     if (!clean) { return undefined; }
-    // Direct model ID match
-    if (modelDisplayNames[clean] !== undefined) { return clean; }
+    // Direct model ID match (API-registered or retired)
+    if (modelDisplayNames[clean] !== undefined || LEGACY_MODEL_NAMES[clean] !== undefined) { return clean; }
     // Reverse lookup: display label → model ID
     for (const [modelId, label] of Object.entries(modelDisplayNames)) {
         if (label === clean) {
@@ -136,12 +148,25 @@ export function normalizeModelDisplayName(modelOrDisplay: string): string {
     if (!modelId) { return clean; }
     const displayName = getModelDisplayName(modelId);
     const shortId = getModelShortId(modelId);
-    // Append diagnostic short ID when display name is resolved (not raw placeholder)
-    // e.g. "Gemini 3.1 Pro (High)" + "M16" → "Gemini 3.1 Pro (High) (M16)"
-    if (shortId && displayName !== modelId && !displayName.includes(`(${shortId})`)) {
+    // Append diagnostic short ID when enabled and display name is resolved
+    if (showModelShortId && shortId && displayName !== modelId && !displayName.includes(`(${shortId})`)) {
         return `${displayName} (${shortId})`;
     }
     return displayName;
+}
+
+/**
+ * Get the base display name WITHOUT the diagnostic (Mxx) suffix.
+ * Used as a stable aggregation key for cost/pricing merging, so that the
+ * same model under different internal IDs (e.g. M37 and M16 both being
+ * "Gemini 3.1 Pro (High)") can be merged into a single cost row.
+ */
+export function getModelBaseName(modelOrDisplay: string): string {
+    const clean = modelOrDisplay.trim();
+    if (!clean) { return ''; }
+    const modelId = resolveModelId(clean);
+    if (!modelId) { return clean; }
+    return getModelDisplayName(modelId);
 }
 
 /**
@@ -264,4 +289,17 @@ export function registerResponseModelAlias(responseModel: string, placeholderId:
     if (responseModel && placeholderId && responseModel !== placeholderId) {
         responseModelAliases[responseModel] = placeholderId;
     }
+}
+
+/**
+ * Enable/disable the diagnostic short ID suffix on normalizeModelDisplayName().
+ * When enabled, model names display as "Gemini 3.1 Pro (High) (M16)" etc.
+ */
+export function setShowModelShortId(enabled: boolean): void {
+    showModelShortId = enabled;
+}
+
+/** Check whether the diagnostic short ID suffix is currently enabled. */
+export function isShowModelShortId(): boolean {
+    return showModelShortId;
 }

--- a/src/pricing-panel.ts
+++ b/src/pricing-panel.ts
@@ -8,7 +8,7 @@ import { PricingStore, DEFAULT_PRICING, PRICING_LAST_UPDATED, findPricing, Model
 import { esc } from './webview-helpers';
 import type { MonthCostBreakdown } from './daily-store';
 import { getModelDNAKey, type PersistedModelDNA } from './model-dna-store';
-import { ModelConfig, normalizeModelDisplayName } from './models';
+import { ModelConfig, normalizeModelDisplayName, getModelBaseName } from './models';
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -1334,21 +1334,30 @@ function buildMonthlyCostSummary(
 
     // 1. Archived cycles from DailyStore
     for (const m of breakdown.models) {
-        const cleanName = normalizeModelDisplayName(m.name) || m.name;
-        mergedModels.set(cleanName, {
-            name: cleanName,
-            totalCost: m.totalCost,
-            calls: m.calls,
-            inputTokens: m.inputTokens,
-            outputTokens: m.outputTokens,
-            thinkingTokens: m.thinkingTokens,
-        });
+        const cleanName = getModelBaseName(m.name) || m.name;
+        const existing = mergedModels.get(cleanName);
+        if (existing) {
+            existing.totalCost += m.totalCost;
+            existing.calls += m.calls;
+            existing.inputTokens += m.inputTokens;
+            existing.outputTokens += m.outputTokens;
+            existing.thinkingTokens += m.thinkingTokens;
+        } else {
+            mergedModels.set(cleanName, {
+                name: cleanName,
+                totalCost: m.totalCost,
+                calls: m.calls,
+                inputTokens: m.inputTokens,
+                outputTokens: m.outputTokens,
+                thinkingTokens: m.thinkingTokens,
+            });
+        }
     }
 
     // 2. Current live cycle (not yet archived)
     if (isCurrentMonth && currentCycleRows.length > 0) {
         for (const row of currentCycleRows) {
-            const key = normalizeModelDisplayName(row.name) || row.name;
+            const key = getModelBaseName(row.name) || row.name;
             const existing = mergedModels.get(key);
             if (existing) {
                 existing.totalCost += row.totalCost;

--- a/src/pricing-store.ts
+++ b/src/pricing-store.ts
@@ -50,6 +50,7 @@ export const DEFAULT_PRICING: Record<string, ModelPricing> = {
     'gpt-oss-120b': { input: 0.09, output: 0.36, cacheRead: 0, cacheWrite: 0, thinking: 0.36 },
     // ── Gemini 3.x (cloud.google.com/vertex-ai/generative-ai/pricing) ─
     'gemini-3.1-pro': { input: 2, output: 12, cacheRead: 0.20, cacheWrite: 2.50, thinking: 12 },
+    'gemini-pro-default': { input: 2, output: 12, cacheRead: 0.20, cacheWrite: 2.50, thinking: 12 },  // M16 responseModel alias
     'gemini-3-flash': { input: 0.50, output: 3, cacheRead: 0.05, cacheWrite: 0.625, thinking: 3 },
 };
 

--- a/src/pricing-store.ts
+++ b/src/pricing-store.ts
@@ -5,7 +5,7 @@
 // Extracted from gm-panel.ts to enable the dedicated Pricing tab.
 
 import type { GMSummary, GMModelStats } from './gm-tracker';
-import { normalizeModelDisplayName } from './models';
+import { normalizeModelDisplayName, getModelBaseName } from './models';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -98,45 +98,49 @@ export function calculateCosts(
 ): { rows: ModelCostRow[]; grandTotal: number } {
     const mergedTable = { ...DEFAULT_PRICING, ...customPricing };
     const entries = Object.entries(summary.modelBreakdown);
-    const rows: ModelCostRow[] = [];
+    // Merge rows by base model name (e.g. M37 + M16 both → "Gemini 3.1 Pro (High)")
+    const mergedRows = new Map<string, ModelCostRow>();
     let grandTotal = 0;
 
     const calcCost = (tokens: number, pricePerM: number) => (tokens / 1_000_000) * pricePerM;
 
     for (const [name, ms] of entries) {
         const displayName = normalizeModelDisplayName(name);
+        const baseName = getModelBaseName(name) || displayName;
         const pricing = findPricing(ms.responseModel, mergedTable);
-        // responseOutputTokens = totalOutputTokens - totalThinkingTokens
-        // This avoids double-counting: outputTokens includes thinking already.
         const responseOutputTokens = Math.max(0, ms.totalOutputTokens - ms.totalThinkingTokens);
-        if (!pricing) {
-            rows.push({
-                name: displayName, responseModel: ms.responseModel,
-                inputCost: 0, outputCost: 0, cacheCost: 0, thinkingCost: 0, totalCost: 0,
-                inputTokens: ms.totalInputTokens, outputTokens: responseOutputTokens,
-                cacheTokens: ms.totalCacheRead,
-                thinkingTokens: ms.totalThinkingTokens, pricing: null,
-            });
-            continue;
-        }
 
-        const inputCost = calcCost(ms.totalInputTokens, pricing.input);
-        const outputCost = calcCost(responseOutputTokens, pricing.output);
-        const cacheCost = calcCost(ms.totalCacheRead, pricing.cacheRead);
-        const thinkingCost = calcCost(ms.totalThinkingTokens, pricing.thinking);
+        const inputCost = pricing ? calcCost(ms.totalInputTokens, pricing.input) : 0;
+        const outputCost = pricing ? calcCost(responseOutputTokens, pricing.output) : 0;
+        const cacheCost = pricing ? calcCost(ms.totalCacheRead, pricing.cacheRead) : 0;
+        const thinkingCost = pricing ? calcCost(ms.totalThinkingTokens, pricing.thinking) : 0;
         const totalCost = inputCost + outputCost + cacheCost + thinkingCost;
         grandTotal += totalCost;
 
-        rows.push({
-            name: displayName, responseModel: ms.responseModel,
-            inputCost, outputCost, cacheCost, thinkingCost, totalCost,
-            inputTokens: ms.totalInputTokens, outputTokens: responseOutputTokens,
-            cacheTokens: ms.totalCacheRead,
-            thinkingTokens: ms.totalThinkingTokens, pricing,
-        });
+        const existing = mergedRows.get(baseName);
+        if (existing) {
+            existing.inputCost += inputCost;
+            existing.outputCost += outputCost;
+            existing.cacheCost += cacheCost;
+            existing.thinkingCost += thinkingCost;
+            existing.totalCost += totalCost;
+            existing.inputTokens += ms.totalInputTokens;
+            existing.outputTokens += responseOutputTokens;
+            existing.cacheTokens += ms.totalCacheRead;
+            existing.thinkingTokens += ms.totalThinkingTokens;
+            if (!existing.pricing && pricing) { existing.pricing = pricing; }
+        } else {
+            mergedRows.set(baseName, {
+                name: displayName, responseModel: ms.responseModel,
+                inputCost, outputCost, cacheCost, thinkingCost, totalCost,
+                inputTokens: ms.totalInputTokens, outputTokens: responseOutputTokens,
+                cacheTokens: ms.totalCacheRead,
+                thinkingTokens: ms.totalThinkingTokens, pricing: pricing || null,
+            });
+        }
     }
 
-    rows.sort((a, b) => b.totalCost - a.totalCost);
+    const rows = [...mergedRows.values()].sort((a, b) => b.totalCost - a.totalCost);
     return { rows, grandTotal };
 }
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ContextUsage } from './tracker';
 import { ModelConfig } from './models';
+import { isShowModelShortId } from './models';
 import { t, tBi, getLanguage } from './i18n';
 import { formatResetAbsolute, formatResetContext, formatResetCountdownFromMs } from './reset-time';
 
@@ -371,7 +372,7 @@ export class StatusBarManager {
         lines.push(`——————————`);
 
         if (usage.lastModelUsage) {
-            const cpLabel = usage.checkpointModel
+            const cpLabel = (usage.checkpointModel && isShowModelShortId())
                 ? ` (${escapeMarkdown(shortenShadowModelId(usage.checkpointModel))})`
                 : '';
             lines.push(`📎 ${t('tooltip.lastCheckpoint')}:${cpLabel}`);

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -3,6 +3,7 @@ import { rpcCall } from './rpc-client';
 import {
     getContextLimit,
     getModelDisplayName,
+    normalizeModelDisplayName,
     updateModelDisplayNames,
     ModelConfig,
     FullUserStatus,
@@ -26,6 +27,7 @@ import {
 export {
     getContextLimit,
     getModelDisplayName,
+    normalizeModelDisplayName,
     updateModelDisplayNames,
     ModelConfig,
     FullUserStatus,
@@ -723,7 +725,7 @@ export async function getContextUsage(
         cascadeId: trajectory.cascadeId,
         title: trajectory.summary,
         model: effectiveModel,
-        modelDisplayName: getModelDisplayName(effectiveModel),
+        modelDisplayName: normalizeModelDisplayName(effectiveModel),
         contextUsed: result.contextUsed,
         totalOutputTokens: result.totalOutputTokens,
         totalToolCallOutputTokens: result.totalToolCallOutputTokens,

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -100,6 +100,7 @@ function sanitizeConfigValue(key: string, value: unknown): unknown {
         case 'statusBar.showContext':
         case 'statusBar.showQuota':
         case 'statusBar.showResetCountdown':
+        case 'showModelInternalId':
             return !!value;
         case 'quotaNotificationThreshold':
             return clamp(Number(value) || 0, 0, 99);
@@ -364,6 +365,7 @@ export function showMonitorPanel(p: PanelPayload): void {
                 'statusBar.showContext',
                 'statusBar.showQuota',
                 'statusBar.showResetCountdown',
+                'showModelInternalId',
                 'contextLimits',
                 'quotaNotificationThreshold',
                 'activity.maxRecentSteps',

--- a/src/webview-script.ts
+++ b/src/webview-script.ts
@@ -517,8 +517,8 @@ export function getScript(): string {
             if (zoomValEl) { zoomValEl.textContent = zoomLevel + '%'; }
 
             // ─── Settings: Status Bar Toggles ───
-            var toggleIds = ['toggleContext', 'toggleQuota', 'toggleCountdown'];
-            var toggleKeys = ['statusBar.showContext', 'statusBar.showQuota', 'statusBar.showResetCountdown'];
+            var toggleIds = ['toggleContext', 'toggleQuota', 'toggleCountdown', 'toggleModelInternalId'];
+            var toggleKeys = ['statusBar.showContext', 'statusBar.showQuota', 'statusBar.showResetCountdown', 'showModelInternalId'];
             for (var tgi = 0; tgi < toggleIds.length; tgi++) {
                 (function(idx) {
                     var cb = document.getElementById(toggleIds[idx]);

--- a/src/webview-settings-tab.ts
+++ b/src/webview-settings-tab.ts
@@ -44,6 +44,7 @@ export function buildSettingsContent(
     const showContext = cfg.get<boolean>('statusBar.showContext', true);
     const showQuota = cfg.get<boolean>('statusBar.showQuota', true);
     const showResetCountdown = cfg.get<boolean>('statusBar.showResetCountdown', true);
+    const showModelInternalId = cfg.get<boolean>('showModelInternalId', false);
     const quotaNotifyThreshold = cfg.get<number>('quotaNotificationThreshold', 20);
     const tabScrollHintEnabled = panelPrefs?.showTabScrollHint ?? true;
     const showScrollbar = panelPrefs?.showScrollbar ?? false;
@@ -221,7 +222,25 @@ export function buildSettingsContent(
                 <label class="toggle-row">
                     <input type="checkbox" id="toggleCountdown" class="toggle-cb" ${showResetCountdown ? 'checked' : ''} />
                     <span class="toggle-track"><span class="toggle-thumb"></span></span>
-                    <span>${tBi('Reset countdown', '重置倒计时')} <code>⏳4h32m</code></span>
+                    <span>${tBi('Reset countdown', '重置倒计时')} <code>&#x23F3;4h32m</code></span>
+                </label>
+            </div>
+        </section>
+
+        <section class="stg-card" data-accent="display">
+            <div class="stg-header">
+                <span class="stg-header-icon">${ICON.chart}</span>
+                <h2>${tBi('Advanced Display', '高级显示')}</h2>
+            </div>
+            <p class="raw-desc">${tBi(
+        'Show extra diagnostic information useful for tracking platform-level model changes.',
+        '显示用于追踪平台级模型变更的诊断信息。',
+    )}</p>
+            <div class="toggle-group">
+                <label class="toggle-row">
+                    <input type="checkbox" id="toggleModelInternalId" class="toggle-cb" ${showModelInternalId ? 'checked' : ''} />
+                    <span class="toggle-track"><span class="toggle-thumb"></span></span>
+                    <span>${tBi('Show model internal ID', '显示模型内部 ID')} <code>(M16)</code></span>
                 </label>
             </div>
         </section>

--- a/src/webview-styles.ts
+++ b/src/webview-styles.ts
@@ -3777,7 +3777,6 @@ export function getStyles(): string {
             margin-bottom: 0;
         }
         .acct-popover-body .acct-card {
-            flex-wrap: wrap;
             gap: var(--space-2);
         }
         .acct-popover-body .acct-identity {
@@ -3785,7 +3784,7 @@ export function getStyles(): string {
             min-width: 140px;
         }
         .acct-popover-body .acct-pools {
-            flex: 1 1 100%;
+            flex: 0 1 auto;
             min-width: 0;
         }
         .acct-popover-body .acct-pool-model {


### PR DESCRIPTION
## 概述

适配 Gemini 平台模型重映射（M16/M84），完善成本计算和退役模型兜底，并优化账号面板 UI。

## 主要改动

### 模型生态适配
- **M16/M84 适配**：M16 取代 M37（Gemini 3.1 Pro High），M84 取代 M47（Gemini 3 Flash），补充静态限额和额度池映射
- **responseModel 反向别名解析**：GM 数据自动学习 `gemini-pro-default` → M16 映射，显示正确模型名
- **退役模型兜底**：`LEGACY_MODEL_NAMES` 确保历史日历/成本数据中 M37/M47 显示正确名称
- **成本合并**：同模型不同 ID（M37+M16）合并为一行显示总额

### 诊断 ID 开关
- 新增 `showModelInternalId` 设置项（默认关闭）
- 开启后模型名追加 `(M16)`、`(M26)` 等短标识
- 状态栏 tooltip 影子模型标识同步受控
- 设置面板「高级显示」区域提供 toggle

### 账号面板优化
- 每个账号卡片显示积分余额（如 GOOGLE ONE AI 18,350）
- 身份区拆为四行：名字+状态、邮箱、会员计划、积分
- 配额池进度条移至最右侧对齐
- 修复 popover 布局空白问题

### 涉及文件
`models.ts`, `tracker.ts`, `extension.ts`, `pricing-store.ts`, `pricing-panel.ts`, `activity-panel.ts`, `webview-panel.ts`, `webview-styles.ts`, `webview-settings-tab.ts`, `webview-script.ts`, `statusbar.ts`, `package.json`