### PR TITLE
Fix language selection persistence across sessions

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -119,9 +119,12 @@ export function getLanguage(): Language {
 /**
  * Set and persist the display language.
  */
-export async function setLanguage(lang: Language, context: vscode.ExtensionContext): Promise<void> {
+export async function setLanguage(lang: Language, context: vscode.ExtensionContext, state?: StateBucket): Promise<void> {
     currentLanguage = lang;
     await context.globalState.update('displayLanguage', lang);
+    if (state) {
+        await state.update('displayLanguage', lang);
+    }
 }
 
 export async function setLanguageToState(lang: Language, state: StateBucket): Promise<void> {

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -334,7 +334,7 @@ export function showMonitorPanel(p: PanelPayload): void {
 
     panel.webview.onDidReceiveMessage(async (msg: { command: string; lang?: string; value?: unknown; key?: string; action?: string; cascadeId?: string; uri?: string; email?: string; day?: number }) => {
         if (msg.command === 'switchLanguage' && msg.lang && extensionCtx) {
-            await setLanguage(msg.lang as Language, extensionCtx);
+            await setLanguage(msg.lang as Language, extensionCtx, panelDurableState);
             if (panel) {
                 panel.webview.html = buildHtml(lastUsage, lastAllUsages, lastConfigs, lastUserInfo, isPaused, lastQuotaTracker);
             }


### PR DESCRIPTION
Problem: > The language setting resets to "both" every time Antigravity restarts.

Solution: > Updated the application to correctly persist and load the user's selected language preference between sessions.