### PR TITLE
修复旧日期空账本阻塞今日累计

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 ### 🐛 Fixed / 修复
 
+- **Today's Ledger recovers from stale empty state / 今日累计可从旧日期空状态恢复**:
+  DailyLedger restore now normalizes a previous-day empty ledger to today's date instead of preserving a stale `dateKey` with no data to archive. This prevents new calls from being extracted repeatedly but rejected with `added=0`, which kept the "Today's Ledger / 今日累计" panel hidden after a no-usage previous day.
+  DailyLedger 恢复时会将“旧日期且无数据”的空账本归一到今天，而不是保留没有归档价值的旧 `dateKey`。这避免前一天无用量后，次日新增调用被反复提取但全部 `added=0` 拒绝，导致“今日累计”面板不显示。
+
 - **Quota-reset settlement no longer triggered by resetTime drift / 额度重置结算不再被 resetTime 漂移误触发**:
   Added a stricter reset-time turnover gate: settlement now requires the previous reset time to have passed and the new reset time to jump forward by a meaningful cycle window. Small future drift or first-use resetTime correction no longer moves today's active ledger into the settled bucket. GM archival filtering now prefers exact archived call IDs when hydrated calls are available, and stale future account-model cutoffs are purged on restore/build/serialize so they cannot keep hiding later same-model calls.
   新增更严格的 resetTime 周期切换判定：只有旧 resetTime 已经过期，并且新 resetTime 向未来发生明确周期跳转时才触发结算。小幅未来漂移或首次使用后的 resetTime 校正，不会再把“今日累计”提前搬到“已结算”。GM 归档过滤在有明细调用时优先使用精确 call ID，恢复态遗留的未来 account-model cutoff 会在 restore/build/serialize 路径清理，避免继续隐藏后续同模型调用。

--- a/src/daily-ledger.ts
+++ b/src/daily-ledger.ts
@@ -710,6 +710,12 @@ export class DailyLedger {
             }
         }
 
+        // A stale empty ledger has nothing to archive, but keeping its old
+        // dateKey makes recordCalls() reject all new calls until restart repair.
+        if (!ledger.hasData && ledger._dateKey !== toLocalDateKey()) {
+            ledger._resetForNewDay(toLocalDateKey());
+        }
+
         return ledger;
     }
 

--- a/tests/daily-ledger-date-filter.test.ts
+++ b/tests/daily-ledger-date-filter.test.ts
@@ -73,4 +73,21 @@ describe('DailyLedger date filtering', () => {
         expect(added).toBe(0);
         expect(ledger.getTodayTotals().totalCalls).toBe(0);
     });
+
+    it('normalizes a restored stale empty ledger so new calls can be recorded today', () => {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        const restored = DailyLedger.restore(new DailyLedger(toLocalDateKey(yesterday)).serialize());
+
+        const now = new Date();
+        now.setHours(12, 0, 0, 0);
+        const added = restored.recordCalls([{
+            call: makeCall(now.toISOString()),
+            dedupKey: 'conv-1:0',
+        }]);
+
+        expect(added).toBe(1);
+        expect(restored.dateKey).toBe(toLocalDateKey(now));
+        expect(restored.getTodayTotals().totalCalls).toBe(1);
+    });
 });


### PR DESCRIPTION
## 变更

- 修复 DailyLedger 恢复旧日期空账本时不切到今天的问题
- 保留旧日期且有数据账本的原跨天归档行为
- 增加回归测试，覆盖前一天无用量后次日新增调用可进入今日累计
- 更新 CHANGELOG.md 记录该修复

## 验证

- `npm test`：19 个测试文件 / 126 个测试通过
- `npm run compile`：通过