### PR TITLE
fix(discovery): support localized Windows netstat status strings (German ABHÖREN / ABH?REN)

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -300,7 +300,7 @@ export function extractPortFromSs(line: string): number | null {
  * Matches patterns like `TCP    127.0.0.1:12345    0.0.0.0:0    LISTENING    1234`
  */
 export function extractPortFromNetstat(line: string): number | null {
-    const portMatch = line.match(/\s+127\.0\.0\.1:(\d+)\s/);
+    const portMatch = line.match(/\s+(?:127\.0\.0\.1|0\.0\.0\.0|\[::1\]|\[::\]):(\d+)\s/);
     return portMatch ? parseInt(portMatch[1], 10) : null;
 }
 
@@ -309,9 +309,12 @@ export function extractPortFromNetstat(line: string): number | null {
  * CR-#62: the previous `line.trim().endsWith(String(pid))` matched PID 123
  * against a line owned by 1123 (substring suffix). Anchor on the final
  * whitespace-delimited field (the PID column) for an exact match instead.
+ *
+ * Supports localized Windows netstat status strings (e.g. German "ABHÖREN" / "ABH?REN").
  */
 export function netstatLineMatchesPid(line: string, pid: number): boolean {
-    if (!line.includes('LISTENING')) { return false; }
+    const isListening = line.includes('LISTENING') || line.includes('ABH') || line.includes('0.0.0.0:0') || line.includes('[::]:0');
+    if (!isListening) { return false; }
     const m = line.trim().match(/\s(\d+)$/);
     return m !== null && m[1] === String(pid);
 }

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -425,6 +425,13 @@ describe('netstatLineMatchesPid (CR-#62)', () => {
         expect(netstatLineMatchesPid(line, 19472)).toBe(true);
     });
 
+    it('matches localized German Windows netstat status (ABHÖREN / ABH?REN)', () => {
+        const lineGerman1 = '  TCP    127.0.0.1:61588    0.0.0.0:0              ABHÖREN         16632';
+        const lineGerman2 = '  TCP    127.0.0.1:61588    0.0.0.0:0              ABH?REN         16632';
+        expect(netstatLineMatchesPid(lineGerman1, 16632)).toBe(true);
+        expect(netstatLineMatchesPid(lineGerman2, 16632)).toBe(true);
+    });
+
     it('does NOT match a PID that is only a suffix of the owning PID (123 vs 1123)', () => {
         const line = '  TCP    127.0.0.1:8558    0.0.0.0:0    LISTENING    1123';
         expect(netstatLineMatchesPid(line, 123)).toBe(false);
@@ -432,7 +439,9 @@ describe('netstatLineMatchesPid (CR-#62)', () => {
 
     it('ignores non-LISTENING lines', () => {
         const line = '  TCP    127.0.0.1:8558    127.0.0.1:5000    ESTABLISHED    19472';
+        const lineGermanEst = '  TCP    10.106.155.19:56602    172.217.112.4:443      HERGESTELLT     16632';
         expect(netstatLineMatchesPid(line, 19472)).toBe(false);
+        expect(netstatLineMatchesPid(lineGermanEst, 16632)).toBe(false);
     });
 });
 


### PR DESCRIPTION
Fixes #64

### Summary of Changes
- Updated \
etstatLineMatchesPid\ in \src/discovery.ts\ to accept localized Windows \
etstat -ano\ listening state strings (e.g., German \ABHÖREN\ / \ABH?REN\) alongside \LISTENING\ and wildcard listening addresses (\